### PR TITLE
Be explicit about data that is sent to displays

### DIFF
--- a/src/pubsub/pubsub-update.js
+++ b/src/pubsub/pubsub-update.js
@@ -49,7 +49,8 @@ function updateEntry(data) {
 
 function distribute(watchersPromise) {
   return watchersPromise.then(data=>{
-    let msg = {...data, topic: "MSFILEUPDATE"};
+    const {filePath, version, type} = data;
+    let msg = {filePath, version, type, topic: "MSFILEUPDATE"};
 
     data.watchers.forEach(watcher=>{
       msg = msg.type === "DELETE" ?


### PR DESCRIPTION
We wan't to at least ensure that the wathchers list of displayIds
isn't being sent to all displays.