### PR TITLE
Allow content-type explicitly for CORS

### DIFF
--- a/src/webhooks/presence/set-cors-headers.js
+++ b/src/webhooks/presence/set-cors-headers.js
@@ -10,6 +10,6 @@ module.exports = (req, resp) => {
 
   resp.set({
     "Access-Control-Allow-Origin": allowedOrigin,
-    "Access-Control-Allow-Headers": "*"
+    "Access-Control-Allow-Headers": req.get("access-control-request-headers") || "*"
   });
 };


### PR DESCRIPTION
This should fix [apps issue 579](https://github.com/Rise-Vision/rise-vision-apps/issues/579#issuecomment-371948945)

@rudibravo fyi