### PR TITLE
Fix/add last changed to watch result

### DIFF
--- a/src/event-handlers/messages/folder-watch.js
+++ b/src/event-handlers/messages/folder-watch.js
@@ -27,11 +27,14 @@ module.exports = {
       });
     })
     .then((folderData)=>{
-      displayConnections.sendMessage(displayId, {
-        msg: "ok",
-        topic: "watch-result",
-        folderData
-      });
+      return watchList.lastChanged(displayId)
+      .then(watchlistLastChanged =>
+        displayConnections.sendMessage(displayId, {
+          msg: "ok",
+          topic: "watch-result",
+          folderData,
+          watchlistLastChanged
+        }));
     })
     .catch((err)=>{
       watchError(err, folderPath, displayId);

--- a/src/event-handlers/messages/watch.js
+++ b/src/event-handlers/messages/watch.js
@@ -37,13 +37,17 @@ module.exports = {
     return Promise.all(asyncTasks)
     .then(all=>{
       const finalResult = all[asyncTasks.length - 1];
-      displayConnections.sendMessage(newEntry.displayId, {
-        msg: "ok",
-        topic: "watch-result",
-        filePath,
-        version: finalResult.version,
-        token: finalResult.token
-      });
+
+      return db.watchList.lastChanged(displayId)
+      .then(watchlistLastChanged =>
+        displayConnections.sendMessage(displayId, {
+          msg: "ok",
+          topic: "watch-result",
+          filePath,
+          version: finalResult.version,
+          token: finalResult.token,
+          watchlistLastChanged
+        }));
     })
     .catch((err)=>{
       watchError(err, filePath, newEntry.displayId);

--- a/test/integration/folder-watch.js
+++ b/test/integration/folder-watch.js
@@ -54,7 +54,7 @@ describe("FOLDER-WATCH : Integration", ()=>{
       assert(md.addDisplayToMany.called);
       assert(watchList.putFolder.called);
       assert(folders.addFileNames.called);
-      verifyReply(displayId, 1);
+      verifyReply(displayId, 1, fakeTimestamp);
 
       return watchList.lastChanged(displayId);
     })
@@ -72,7 +72,7 @@ describe("FOLDER-WATCH : Integration", ()=>{
       assert.equal(md.setMultipleFileVersions.callCount, 1);
       assert.equal(md.addDisplayToMany.callCount, 2); // eslint-disable-line no-magic-numbers
       assert.equal(watchList.putFolder.callCount, 2); // eslint-disable-line no-magic-numbers
-      verifyReply("someOtherDisplay", 2); // eslint-disable-line no-magic-numbers
+      verifyReply("someOtherDisplay", 2, fakeTimestamp2); // eslint-disable-line no-magic-numbers
 
       return watchList.lastChanged("someOtherDisplay");
     })
@@ -80,7 +80,7 @@ describe("FOLDER-WATCH : Integration", ()=>{
       assert.equal(lastChanged, fakeTimestamp2);
     });
 
-    function verifyReply(id, replyCount) {
+    function verifyReply(id, replyCount, lastChanged) {
       const [repliedTo, reply] = displayConnections.sendMessage.lastCall.args;
 
       assert.equal(displayConnections.sendMessage.callCount, replyCount);
@@ -88,7 +88,7 @@ describe("FOLDER-WATCH : Integration", ()=>{
       assert.equal(reply.msg, "ok");
       assert.equal(reply.topic, "watch-result");
       assert.equal(reply.folderData.length, 2); // eslint-disable-line no-magic-numbers
-      assert.equal(reply.watchlistLastChanged, fakeTimestamp2);
+      assert.equal(reply.watchlistLastChanged, lastChanged);
 
       assert(reply.folderData.some(entry=>entry.filePath.includes(filePath1)));
       assert(reply.folderData.some(entry=>entry.filePath.includes(filePath2)));

--- a/test/integration/folder-watch.js
+++ b/test/integration/folder-watch.js
@@ -88,6 +88,8 @@ describe("FOLDER-WATCH : Integration", ()=>{
       assert.equal(reply.msg, "ok");
       assert.equal(reply.topic, "watch-result");
       assert.equal(reply.folderData.length, 2); // eslint-disable-line no-magic-numbers
+      assert.equal(reply.watchlistLastChanged, fakeTimestamp2);
+
       assert(reply.folderData.some(entry=>entry.filePath.includes(filePath1)));
       assert(reply.folderData.some(entry=>entry.filePath.includes(filePath2)));
       assert(reply.folderData.some(entry=>entry.version.includes(fileVersion)));

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -76,6 +76,8 @@ describe("WATCH : Integration", ()=>{
         assert.ok(reply.token.hash);
         assert.ok(reply.token.data.timestamp);
         assert.equal(reply.version, knownGCSversion);
+        assert.equal(reply.watchlistLastChanged, fakeTimestamp);
+
         assert(gcs.version.called);
         return redis.getString(`meta:${validFilePath}:version`)
         .then(string=> assert.equal(string, knownGCSversion));
@@ -105,6 +107,8 @@ describe("WATCH : Integration", ()=>{
         assert(!reply.token);
         assert.equal(reply.msg, "ok");
         assert.equal(reply.version, knownGCSversion);
+        assert.equal(reply.watchlistLastChanged, fakeTimestamp);
+
         assert(!gcs.version.called);
 
         return watchList.lastChanged(displayId);

--- a/test/unit/folder-watch.js
+++ b/test/unit/folder-watch.js
@@ -15,6 +15,7 @@ describe("WATCH (FOLDER)", ()=>{
     simple.mock(db.fileMetadata, "setMultipleFileVersions").resolveWith(true);
     simple.mock(db.watchList, "put").returnWith(true);
     simple.mock(db.watchList, "putFolder").returnWith(true);
+    simple.mock(db.watchList, "lastChanged").resolveWith("123456");
     simple.mock(db.folders, "addFileNames").returnWith([]);
     simple.mock(db.folders, "filePathsAndVersionsFor").returnWith([]);
     simple.mock(versionCompare, "compare").resolveWith({matched: true});
@@ -43,6 +44,16 @@ describe("WATCH (FOLDER)", ()=>{
     .then(()=>{
       assert(db.fileMetadata.addDisplayToMany.called);
       assert(db.watchList.putFolder.called);
+      assert(db.watchList.lastChanged.called);
+
+      assert.equal(displayConnections.sendMessage.callCount, 1);
+      assert.equal(displayConnections.sendMessage.lastCall.args[0], displayId);
+
+      const message = displayConnections.sendMessage.lastCall.args[1];
+      assert(message);
+      assert.equal(message.msg, "ok");
+      assert.equal(message.topic, "watch-result");
+      assert.equal(message.watchlistLastChanged, "123456");
     })
   });
 


### PR DESCRIPTION
Both WATCH requests for files and folders may result in updates to the watchlist collection with their corresponding latestChange updates:

- https://github.com/Rise-Vision/messaging-service/blob/master/src/event-handlers/messages/folder-watch.js#L21
- https://github.com/Rise-Vision/messaging-service/blob/master/src/event-handlers/messages/watch.js#L31

So their response messages should include this latestChange value so the display can update this value accordingly.
