### PR TITLE
Don't throw when WATCH file is not on GCS

### DIFF
--- a/src/version-compare/api.js
+++ b/src/version-compare/api.js
@@ -9,7 +9,7 @@ module.exports = {
     .then(version=>version ||
       gcs.version(filePath).then(md.setFileVersion.bind(null, filePath)))
     .then((version)=>({
-      matched: version === checkVersion, version, filePath, displayId
+      matched: version === checkVersion || version === "0", version, filePath, displayId
     }));
   }
 };

--- a/test/integration/gcs.js
+++ b/test/integration/gcs.js
@@ -24,15 +24,11 @@ describe("GCS : Integration", ()=>{
       });
     });
 
-    it("throws on 404", ()=>{
-      const NOT_FOUND = 404;
+    it("Returns version 0 on 404", ()=>{
       const filePath = "messaging-service-test-bucket/nonexistent-file";
 
-      return version(filePath)
-      .then(()=>Promise.reject(Error("Should not have resolved here")))
-      .catch(err=>{
-        if (err.message.startsWith("Should not have")) {throw Error("Fail");}
-        assert.equal(err.code, NOT_FOUND);
+      return version(filePath).then(ver=>{
+        assert.equal(ver, "0");
       });
     });
   });

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -48,14 +48,13 @@ describe("WATCH : Integration", ()=>{
     .then(lastChanged => assert.equal(lastChanged, fakeTimestamp));
   });
 
-  it("returns error if invalid filePath requested", ()=>{
-    const notFound = 404;
+  it("returns error if non-existent filePath requested", ()=>{
     simple.mock(displayConnections, "sendMessage");
 
     return watch.doOnIncomingPod({displayId, filePath: invalidFilePath, version})
     .then(()=>{
       const response = displayConnections.sendMessage.lastCall.args[1];
-      assert.equal(response.error, notFound);
+      assert.equal(response.version, "0");
     })
   });
 


### PR DESCRIPTION
The file should still be stored in metadata for potential ADD from
pubsub. Response to WATCH will be version "0" with no download token.