### PR TITLE
Add support for missing / empty folders

### DIFF
--- a/src/event-handlers/watch-error.js
+++ b/src/event-handlers/watch-error.js
@@ -4,7 +4,8 @@ module.exports = function(err = {}, filePath, displayId) {
   console.error(`[${err.message}] [${filePath}] [${displayId}]`);
 
   displayConnections.sendMessage(displayId, {
-    error: err.code,
+    errorMsg: err.message,
+    errorCode: err.code,
     topic: "watch-result",
     filePath,
     msg: `There was an error processing WATCH:${err.message}`

--- a/src/event-handlers/watch-error.js
+++ b/src/event-handlers/watch-error.js
@@ -4,6 +4,7 @@ module.exports = function(err = {}, filePath, displayId) {
   console.error(`[${err.message}] [${filePath}] [${displayId}]`);
 
   displayConnections.sendMessage(displayId, {
+    error: err.message,
     errorMsg: err.message,
     errorCode: err.code,
     topic: "watch-result",

--- a/src/gcs.js
+++ b/src/gcs.js
@@ -40,9 +40,20 @@ module.exports = {
       delimiter: "/",
       fields: "items(name,generation)"
     })
-    .then(files=>files[0]
-    .filter(file=>!file.name.endsWith("/"))
-    .map(fileObject=>fileObject.metadata));
+    .then(files=>{
+      if (files[0].length === 0) {
+        return Promise.reject(Error("NOEXIST"))
+      }
+
+      const nonFolderFiles = files[0]
+      .filter(file=>!file.name.endsWith("/"));
+
+      if (nonFolderFiles.length === 0) {
+        return Promise.reject(Error("EMPTYFOLDER"));
+      }
+
+      return nonFolderFiles.map(fileObject=>fileObject.metadata);
+    });
   }
 };
 


### PR DESCRIPTION
Fixes an issue when submitting a WATCH on a missing / empty folder and
adds support for both cases so that clients can handle them
specifically.