### PR TITLE
Report folder watching correctly

### DIFF
--- a/src/db/api.js
+++ b/src/db/api.js
@@ -207,7 +207,7 @@ module.exports = {
         filePathOrFolderPath :
         `${dirname(filePathOrFolderPath)}/`;
 
-      return redis.keyExists(`folders:${folderPath}`);
+      return redis.keyExists(`meta:${folderPath}:displays`);
     }
   }
 };

--- a/src/event-handlers/messages/folder-watch.js
+++ b/src/event-handlers/messages/folder-watch.js
@@ -16,6 +16,10 @@ module.exports = {
       return watching ? existingFolder(folderPath) : newFolder(folderPath);
     })
     .then(filePathsAndVersions=>{
+      if (!filePathsAndVersions.length) {
+        return Promise.reject(Error("EMPTYFOLDER"));
+      }
+
       return Promise.all([
         md.addDisplayToMany(filePathsAndVersions, displayId),
         watchList.putFolder(filePathsAndVersions, displayId)

--- a/test/integration/folder-watch.js
+++ b/test/integration/folder-watch.js
@@ -37,8 +37,9 @@ describe("FOLDER-WATCH : Integration", ()=>{
 
   it("indicates whether a folder is being watched", ()=>{
     const mockFolderPath = "my-test-bucket/my-test-folder/";
+    const mockDisplayId = "ABC123";
 
-    return redis.setString(`folders:${mockFolderPath}`, "")
+    return redis.setAdd(`meta:${mockFolderPath}:displays`, [mockDisplayId])
     .then(()=>folders.watchingFolder(mockFolderPath))
     .then(watching=>assert.equal(watching, 1));
   });

--- a/test/unit/folder-watch.js
+++ b/test/unit/folder-watch.js
@@ -11,12 +11,12 @@ describe("WATCH (FOLDER)", ()=>{
   beforeEach(()=>{
     simple.mock(displayConnections, "sendMessage").returnWith(true);
     simple.mock(db.fileMetadata, "addDisplayTo").returnWith(true);
-    simple.mock(db.fileMetadata, "addDisplayToMany").callFn(input=>input);
-    simple.mock(db.fileMetadata, "setMultipleFileVersions").resolveWith(true);
+    simple.mock(db.fileMetadata, "addDisplayToMany").callFn(input=>Promise.resolve(input));
+    simple.mock(db.fileMetadata, "setMultipleFileVersions").callFn(input=>Promise.resolve(input));
     simple.mock(db.watchList, "put").returnWith(true);
-    simple.mock(db.watchList, "putFolder").returnWith(true);
+    simple.mock(db.watchList, "putFolder").callFn(input=>Promise.resolve(input));
     simple.mock(db.watchList, "lastChanged").resolveWith("123456");
-    simple.mock(db.folders, "addFileNames").returnWith([]);
+    simple.mock(db.folders, "addFileNames").callFn((path, input)=>Promise.resolve(input));
     simple.mock(db.folders, "filePathsAndVersionsFor").returnWith([]);
     simple.mock(versionCompare, "compare").resolveWith({matched: true});
   });


### PR DESCRIPTION
`meta:[folderPath]:displays` is a SET that contains any display id that is
watching the folder. This should be used instead of `folder:[folderPath]`
since that is a list of files in the folder which could be empty if all
files have been removed from the folder.

`meta:[folderPath]:displays` is set during folder watch as part of
`addDisplayToMany`.