### PR TITLE
Don't duplicate ADD messages when watching folders

### DIFF
--- a/src/db/api.js
+++ b/src/db/api.js
@@ -2,7 +2,6 @@ const {basename, dirname} = require("path");
 const logger = require("../logger");
 const redis = require("./redis/datastore.js");
 
-const getSetCommand = "getSet";
 const patchHashCommand = "patchHash";
 const removeHashFieldCommand = "removeHashField";
 const setAddCommand = "setAdd";
@@ -44,10 +43,10 @@ module.exports = {
 
       const folderPath = `${dirname(filePath)}/`;
 
-      return redis.multi([
-        [getSetCommand, `meta:${filePath}:displays`],
-        [getSetCommand, `meta:${folderPath}:displays`]
-      ]).then(resp=>resp[0].concat(resp[1]));
+      return redis.setUnion([
+        `meta:${filePath}:displays`,
+        `meta:${folderPath}:displays`
+      ]);
     },
     getFileVersion(filePath) {
       if (!filePath) {throw Error("missing params");}

--- a/src/db/redis/datastore.js
+++ b/src/db/redis/datastore.js
@@ -4,7 +4,7 @@ const gkeHostname = "display-ms-redis-master";
 const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : gkeHostname;
 
 let client = null;
-let promisified = ["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "smembers", "flushall", "sismember", "exists"];
+let promisified = ["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "smembers", "flushall", "sismember", "exists", "sunion"];
 
 module.exports = {
   initdb(dbclient = null) {
@@ -20,6 +20,10 @@ module.exports = {
   setAdd(key, vals) {
     if (!Array.isArray(vals)) {throw Error("expected array");}
     return promisified.sadd(key, ...vals);
+  },
+  setUnion(keys) {
+    if (!Array.isArray(keys)) {throw Error("expected array");}
+    return promisified.sunion(...keys);
   },
   setHas(key, val) {
     return promisified.sismember(key, val);


### PR DESCRIPTION
Concatenating sets results in a watchers list that has duplicate display
ids if a display is watching the folder *and* the file.

This ensures we get unique displayids.

@stulees This is why you were sometimes seeing duplicate *ADD* messages during your testing.