### PR TITLE
Add files to folders when updated

### DIFF
--- a/src/event-handlers/messages/gcs-file-update.js
+++ b/src/event-handlers/messages/gcs-file-update.js
@@ -49,7 +49,7 @@ module.exports = {
 };
 
 function addIntoFolder(data) {
-  if (data.type !== "ADD") {return Promise.resolve(data);}
+  if (!["ADD", "UPDATE"].includes(data.type)) {return Promise.resolve(data);}
 
   return db.folders.watchingFolder(data.filePath)
   .then(watching=>{


### PR DESCRIPTION
Overwriting a file that is trashed is coming through as an update from
PSC because it's an overwrite of an existing file on GCS.

MS needs to add these back into the folder's list of files. It would
have been removed as part of the previous trashing. 