### PR TITLE
Reset folder file lists one time

### DIFF
--- a/src/db/api.js
+++ b/src/db/api.js
@@ -75,7 +75,7 @@ module.exports = {
       }));
     },
     deleteMetadata(filePath) {
-      return redis.deleteKey([`meta:${filePath}:displays`, `meta:${filePath}:version`]);
+      return redis.deleteKeys([`meta:${filePath}:displays`, `meta:${filePath}:version`]);
     },
     hasMetadata(filePath) {
       return redis.hasKey(`meta:${filePath}:version`);
@@ -207,6 +207,14 @@ module.exports = {
         `${dirname(filePathOrFolderPath)}/`;
 
       return redis.keyExists(`meta:${folderPath}:displays`);
+    },
+    folderHasBeenReset(folderPath) {
+      return redis.setHas(`folders:cleared`, folderPath)
+    },
+    clearFolderFiles(folderPath) {
+      return redis.deleteKeys([`folders:${folderPath}`])
+      .then(()=>redis.setAdd(`folders:cleared`, [folderPath]))
+      .then(()=>folderPath)
     }
   }
 };

--- a/src/db/redis/datastore.js
+++ b/src/db/redis/datastore.js
@@ -28,7 +28,8 @@ module.exports = {
   setHas(key, val) {
     return promisified.sismember(key, val);
   },
-  deleteKey(keys) {
+  deleteKeys(keys) {
+    if (!Array.isArray(keys)) {throw Error("expected array");}
     return promisified.del(...keys);
   },
   removeHashField(key, field) {

--- a/src/event-handlers/messages/folder-watch.js
+++ b/src/event-handlers/messages/folder-watch.js
@@ -47,13 +47,23 @@ module.exports = {
 };
 
 function existingFolder(folderPath) {
-  return folders.filePathsAndVersionsFor(folderPath);
+  return folders.folderHasBeenReset(folderPath)
+  .then(alreadyReset=>{
+    return alreadyReset ? folders.filePathsAndVersionsFor(folderPath) :
+    resetFolder(folderPath)
+  })
+}
+
+function resetFolder(folderPath) {
+  return folders.clearFolderFiles(folderPath)
+  .then(newFolder)
 }
 
 function newFolder(folderPath) {
   const bucket = folderPath.split("/")[0];
 
-  return gcs.getFiles(folderPath)
+  return folders.clearFolderFiles(folderPath)
+  .then(gcs.getFiles)
   .then(objectNamesAndVersions=>{
     const filePathsAndVersions = objectNamesAndVersions
     .map(({name, generation})=>{

--- a/test/integration/folder-watch.js
+++ b/test/integration/folder-watch.js
@@ -44,6 +44,27 @@ describe("FOLDER-WATCH : Integration", ()=>{
     .then(watching=>assert.equal(watching, 1));
   });
 
+  it("indicates whether a folder has been reset", ()=>{
+    const mockFolderPath = "my-test-bucket/my-test-folder/";
+
+    return redis.setAdd(`folders:cleared`, [mockFolderPath])
+    .then(()=>folders.folderHasBeenReset(mockFolderPath))
+    .then(reset=>assert(reset))
+  });
+
+  it("clears folder files", ()=>{
+    const mockFolderPath = "my-test-bucket/my-test-folder/";
+
+    return redis.setAdd(`folders:${mockFolderPath}`, ['test-folder'])
+    .then(()=>redis.keyExists(`folders:${mockFolderPath}`))
+    .then(exists=>assert(exists))
+    .then(()=>folders.clearFolderFiles(mockFolderPath))
+    .then(()=>redis.keyExists(`folders:${mockFolderPath}`))
+    .then(exists=>assert(!exists))
+    .then(()=>redis.setHas(`folders:cleared`, mockFolderPath))
+    .then(has=>assert(has))
+  });
+
   it("saves a new folder, on subsequent call returns existing data without gcs fetch", ()=>{
     simple.mock(Date, "now").returnWith(fakeTimestamp);
     simple.mock(gcs, "getFiles");


### PR DESCRIPTION
The current folder file lists include some files they should not. Due to
previous bugs, some files that were trashed and then overwritten with
new versions did not get added back into the folder file list. And in
the opposite case, some files that were trashed are in the folder list.