### PR TITLE
Update watchlists with version "0" on deletion

### DIFF
--- a/src/event-handlers/messages/gcs-file-update.js
+++ b/src/event-handlers/messages/gcs-file-update.js
@@ -82,6 +82,7 @@ function deleteEntry(data) {
   logger.log(`Removing entry for ${JSON.stringify(data)}`);
   return Promise.all([
     db.folders.removeFileFromFolder(data.filePath),
+    db.watchList.updateVersion(data.filePath, "0", data.watchers),
     db.fileMetadata.setFileVersion(data.filePath, "0")
   ])
   .then(()=>data);

--- a/test/integration/file-update-handler.js
+++ b/test/integration/file-update-handler.js
@@ -137,6 +137,6 @@ describe("GCS File Update : Integration", ()=>{
     .then(datastore.getSet.bind(null, `meta:${newFile}:displays`))
     .then(set=>assert(set.includes(displayId)))
     .then(() => dbApi.watchList.lastChanged(displayId))
-    .then(lastChanged => assert.equal(lastChanged, fakeTimestamp2));
+    .then(lastChanged => assert.equal(lastChanged, fakeTimestamp3));
   });
 });

--- a/test/unit/file-update-handler.js
+++ b/test/unit/file-update-handler.js
@@ -134,7 +134,7 @@ describe("Pub/sub Update", ()=>{
         });
 
         assert.equal(db.fileMetadata.setFileVersion.callCount, 1);
-        assert.equal(db.watchList.updateVersion.callCount, 0);
+        assert.equal(db.watchList.updateVersion.callCount, 1);
       });
     });
 


### PR DESCRIPTION
There is currently no way that an offline display will become aware
of a deletion.

With this change, when the display comes back online, it can
submit its watchlist-compare request and handle deletions for any
entries that have version "0".