### PR TITLE
Update MS watchlist on version mismatch

### DIFF
--- a/src/event-handlers/messages/watch.js
+++ b/src/event-handlers/messages/watch.js
@@ -37,8 +37,12 @@ module.exports = {
     return Promise.all(asyncTasks)
     .then(all=>{
       const finalResult = all[asyncTasks.length - 1];
+      const watchlistUpdate = finalResult.token ?
+        db.watchList.put({filePath, displayId, version: finalResult.version}) :
+        Promise.resolve();
 
-      return db.watchList.lastChanged(displayId)
+      return watchlistUpdate
+      .then(()=>db.watchList.lastChanged(displayId))
       .then(watchlistLastChanged =>
         displayConnections.sendMessage(displayId, {
           msg: "ok",

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -29,7 +29,7 @@ describe("WATCH : Integration", ()=>{
     .then(redis.getHash.bind(null, `watch:${displayId}`))
     .then((reply)=>{
       assert.deepEqual(reply, {
-        [invalidFilePath]: version
+        [invalidFilePath]: "existing-file-metadata-version"
       });
     });
   });


### PR DESCRIPTION
If the display provided a version that doesn't match the version on MS,
then MS provides a token. In this case the watchlist should also be
updated to the correct version so that future watchlist comparisons
match.