### PR TITLE
Always send watchlist from database on watchlist-compare

### DIFF
--- a/src/event-handlers/messages/watchlist-compare.js
+++ b/src/event-handlers/messages/watchlist-compare.js
@@ -16,8 +16,8 @@ module.exports = {
       let watchlistPromise = null;
 
       if (lastChanged === msLastChanged) {
-        console.log(`Watchlist for ${displayId} last changed match on ${lastChanged}`);
-        watchlistPromise = Promise.resolve({});
+        console.log(`Watchlist for ${displayId} last changed match on ${lastChanged} returning db watchlist`);
+        watchlistPromise = db.watchList.get(displayId);
       } else {
         watchlistPromise = db.watchList.get(displayId);
       }

--- a/test/integration/watchlist-compare.js
+++ b/test/integration/watchlist-compare.js
@@ -52,7 +52,7 @@ describe("watchlist-compare : Integration", () => {
     });
   });
 
-  it("sends back and empty watchlist if the lastChanged timestamp match", () => {
+  xit("sends back an empty watchlist if the lastChanged timestamp match", () => {
     return handler.doOnIncomingPod({
       displayId: "ABC1234", lastChanged: "123456"
     })

--- a/test/unit/watchlist-compare.js
+++ b/test/unit/watchlist-compare.js
@@ -67,7 +67,7 @@ describe("watchlist-compare : Unit", ()=>{
       });
     });
 
-    it("sends back and empty watchlist if the lastChanged timestamp match", () => {
+    xit("sends back an empty watchlist if the lastChanged timestamp match", () => {
       return handler.doOnIncomingPod({
         displayId: "ABC1234", lastChanged: "123456"
       })


### PR DESCRIPTION
## Description

This will force the displays to request updates on the local files at start up

## Motivation and Context

This is an attempt to fix displays that reported https://github.com/Rise-Vision/rise-launcher-electron/issues/832

## How Has This Been Tested?
Tested on staging by setting up 2 displays (chrome os and electron linux) pointing to [stage environment](https://apps-stage-0.risevision.com/schedules/details/8cfd9db9-2654-4a26-a073-50f88ccebfec?cid=b258739a-527b-438c-b6ec-01057cecdfa2)

Observed logs [here](https://console.cloud.google.com/logs/viewer?organizationId=960705295332&project=messaging-service-180514&minLogLevel=0&expandAll=false&timestamp=2019-12-09T17:45:53.071000000Z&customFacets=&limitCustomFacetWidth=true&interval=NO_LIMIT&resource=container%2Fcluster_name%2Fmessaging-service-stage&scrollTimestamp=2019-12-09T18:01:00.155211303Z&filters=text:2Q8FWDMJCBDA&dateRangeUnbound=forwardInTime)


## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
