### PR TITLE
Add a command to clear Local Storage

### DIFF
--- a/src/event-handlers/messages/clear-local-storage-request.js
+++ b/src/event-handlers/messages/clear-local-storage-request.js
@@ -1,0 +1,17 @@
+const redisPubsub = require("../../redis-pubsub");
+const displayConnections = require("../display-connections");
+
+module.exports = {
+  canHandle(data) {
+    return data.msg === "clear-local-storage-request";
+  },
+  doOnIncomingPod(data) {
+    module.exports.doOnAllPods(data);
+    redisPubsub.publishToPods(data);
+  },
+  doOnAllPods(data) {
+    displayConnections.sendMessage(data.displayId || data.did, {
+      msg: "clear-local-storage-request"
+    });
+  }
+};

--- a/test/integration/core-hoook.js
+++ b/test/integration/core-hoook.js
@@ -7,6 +7,7 @@ const BAD_REQUEST = 400;
 const NOT_AUTHORIZED = 403;
 const screenshotHandler = require("../../src/event-handlers/messages/screenshot-request");
 const debugDataRequest = require("../../src/event-handlers/messages/debug-data-request");
+const clearLocalStorageRequest = require("../../src/event-handlers/messages/clear-local-storage-request");
 
 describe("Webhooks : CORE : GET", ()=>{
   it("expects msg parameter", ()=>{
@@ -124,6 +125,18 @@ describe("Webhooks : CORE : GET", ()=>{
     })
     .then(()=>{
       assert(debugDataRequest.doOnIncomingPod.called)
+    });
+  });
+
+  it("responds ok and calls event handler for clear-local-storage-request", ()=>{
+    simple.mock(clearLocalStorageRequest, "doOnIncomingPod").returnWith();
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/core?msg=clear-local-storage-request&did=ABCDE&sk=TEST`,
+      json: true
+    })
+    .then(()=>{
+      assert(clearLocalStorageRequest.doOnIncomingPod.called)
     });
   });
 });


### PR DESCRIPTION
## Description
Add `clear-local-storage-request` command. See [design doc](https://docs.google.com/document/d/1v1-IJMKvSqSQ3picvYycLpZwYAQIJqO8TQb5_vwUkHA/edit?usp=sharing).

## Motivation and Context
This improvement was requested in Development Roadmap. It should also help with resolving the "stale content" issues (see [#832](https://github.com/Rise-Vision/rise-launcher-electron/issues/832) and [#829](https://github.com/Rise-Vision/rise-launcher-electron/issues/829)) if they ever occur.

## How Has This Been Tested?
Tested manually on stage. Unit test added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
