### PR TITLE
Fix/publish heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,33 @@ Connect to local instance
 ```bash
 MS_PORT=[] node test/manual/test.js
 ```
+
+## Deployment
+
+### Mechanism
+Deployment is completed via Circle Ci integration. A new docker image will be
+created and the deployments will be updated to use the new image.
+
+### Monitoring
+Suggested deployment monitoring setup:
+
+ 1. Backend service details screen for the backend that is attached to the /messaging
+    path. This will show backend utilization / rate while the deployment rolls
+    out. It is typical for it to reach capacity and show a yellow hazard sign.
+    See Kubernetes Engine -> Services & Ingress -> Ingress/Backend Services
+
+ 2. Monitor pods during rollout with `watch kubectl get pods`
+
+ 3. Monitor the backend responsiveness by polling the /presence path. For
+    example:
+
+    ``` bash
+    while true; do sleep 5; echo -n $(date); echo -n " ";curl -H
+    "content-type:application/json" -d '["some-displayid"]'
+    "https://services.risevision.com/messaging/presence"; echo;done`
+    ```
+ 4. Monitor a test connection to confirm it only drops once when its pod is
+    terminated. It should not drop while other pods terminate, due to network
+    backend saturation. `DISPLAY_ID=test-id-1 node test/manual/test.js`
+
+ 5. GCP Logging - GKE Cluster Operations (ensure no warnings / errors)

--- a/src/event-handlers/display-connections.js
+++ b/src/event-handlers/display-connections.js
@@ -30,6 +30,11 @@ module.exports = {
 
     logger.debug(`Removed spark for ${displayId} ${spark.id}`);
   },
+  removeById(displayId) {
+    if (!displayId) {return console.error("Missing display id");}
+
+    module.exports.remove(sparks.get(displayId));
+  },
   recordHeartbeat(spark) {
     if (!spark || !spark.query) {return;}
     const displayId = spark.query.displayId === "apps" ?

--- a/src/event-handlers/missed-heartbeat.js
+++ b/src/event-handlers/missed-heartbeat.js
@@ -1,4 +1,3 @@
-const googlePubSub = require("../google-pubsub");
 const displayConnections = require("./display-connections");
 
 const errorContext = "Missed heartbeat (expired connection key):";
@@ -10,6 +9,6 @@ module.exports = {
     if (!displayId) {return console.error(errorMessage, data);}
 
     if (!displayConnections.hasSparkFor(displayId)) {return;}
-    googlePubSub.publishDisconnection(displayId);
+    displayConnections.removeById(displayId);
   }
 };

--- a/test/integration/db-api.js
+++ b/test/integration/db-api.js
@@ -144,18 +144,22 @@ describe("DB API : Integration", ()=>{
   });
 
   describe("recordHeartbeat", ()=>{
-    it("should call update function and set new key", ()=>{
+    it("should call update function if spark is different and set new key", ()=>{
+      const displayId = randomHexString();
+      const sparkId = randomHexString();
+
       return Promise.all([
         new Promise(res=>simple.mock(datastore, "setString").callFn(res)),
-        new Promise(updateFn=>dbApi.connections.recordHeartbeat(randomHexString(), updateFn))
+        new Promise(updateFn=>dbApi.connections.recordHeartbeat(displayId, sparkId, updateFn))
       ]);
     });
 
-    it("should not call update function when setting existing key", ()=>{
-      const testId = randomHexString();
+    it("should not call update function when spark matches", ()=>{
+      const displayId = randomHexString();
+      const sparkId = randomHexString();
 
-      return dbApi.connections.setConnected(testId)
-      .then(()=>dbApi.connections.recordHeartbeat(testId, ()=>{throw Error("should not call")}));
+      return dbApi.connections.setConnected(displayId, sparkId)
+      .then(()=>dbApi.connections.recordHeartbeat(displayId, sparkId, ()=>{throw Error("should not call")}));
     });
 
     function randomHexString() {


### PR DESCRIPTION
## Description
If an out of order redis PUBSUB missed heartbeat message arrives, the
google pubsub message won't be sent unless the spark id matches or is
missing. This way if there was a near simultaneous new connection the
disconnection won't be published.

On incoming heartbeat, publish the pubsub message if the spark id does
not match.

## Motivation and Context
Presence consistency between core index and redis connection database.

## How Has This Been Tested?
Integration tests + manual tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
