### PR TITLE
Feature/check schedules endpoints

### DIFF
--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -69,8 +69,8 @@ module.exports = {
     primus.on("connection", (spark) => {
       logger.debug(`Spark connection from ${JSON.stringify(spark.address)}`);
 
-      if (spark.query && !spark.query.displayId && spark.query.scheduleId) {
-        spark.query.displayId = spark.query.scheduleId;
+      if (spark.query && !spark.query.displayId && spark.query.endpointId) {
+        spark.query.displayId = spark.query.endpointId;
       }
 
       displayConnections.put(spark);

--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -69,6 +69,10 @@ module.exports = {
     primus.on("connection", (spark) => {
       logger.debug(`Spark connection from ${JSON.stringify(spark.address)}`);
 
+      if (spark.query && !spark.query.displayId && spark.query.scheduleId) {
+        spark.query.displayId = spark.query.scheduleId;
+      }
+
       displayConnections.put(spark);
 
       spark.on("end", ()=>{

--- a/test/integration/connection-params-displays.js
+++ b/test/integration/connection-params-displays.js
@@ -1,0 +1,178 @@
+/* eslint-env mocha */
+const gcs = require("../../src/gcs.js");
+const googlePubSub = require("../../src/google-pubsub");
+const dbApi = require("../../src/db/api");
+const datastore = require("../../src/db/redis/datastore.js");
+const simple = require("simple-mock");
+const testPort = 9228;
+const Primus = require("primus");
+const msEndpoint = `http://localhost:${testPort}/messaging/`;
+
+describe("MS Connection : displays : Integration", ()=>{
+  before(()=>{
+    simple.mock(gcs, "init").returnWith();
+    simple.mock(datastore, "initdb").returnWith();
+    simple.mock(googlePubSub, "publish").returnWith(Promise.resolve());
+  });
+
+  after(()=>{
+    simple.restore();
+  });
+
+  describe("With the messaging server under test running it...", ()=>{
+    it("prevents connections without a displayId", ()=>{
+      const displayId = "testId";
+      const machineId = "testMachineId";
+      const msUrl = `${msEndpoint}?XXXXdisplayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/",
+        reconnect: {retries: 0}
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", (err)=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
+    it("prevents connections without a machineId", ()=>{
+      const displayId = "testId";
+      const machineId = "testMachineId";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&XXXXXXmachineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/",
+        reconnect: {retries: 0}
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", (err)=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
+    it("prevents connections with string undefined as a displayId", ()=>{
+      const displayId = "undefined";
+      const machineId = "testMachineId";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/",
+        reconnect: {retries: 0}
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", (err)=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
+    it("prevents connections with string null as a displayId", ()=>{
+      const displayId = "null";
+      const machineId = "testMachineId";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/",
+        reconnect: {retries: 0}
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", (err)=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
+    it("prevents connections with string undefined as a machineId", ()=>{
+      const displayId = "testId";
+      const machineId = "undefined";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/",
+        reconnect: {retries: 0}
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", (err)=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
+    it("prevents connections with string null as a machineId", ()=>{
+      const displayId = "testId";
+      const machineId = "null";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/",
+        reconnect: {retries: 0}
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", (err)=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
+    it("allows a connection with proper display and machine ids", ()=>{
+      simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
+
+      const displayId = "testId";
+      const machineId = "testMachineId";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/"
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", res);
+        ms.on("error", ()=>rej(Error("Should not have prevented the connection")));
+      })
+      .then(()=>ms.end());
+    });
+
+    it("rejects a connection if display id is not valid", ()=>{
+      simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(false);
+
+      const displayId = "testId";
+      const machineId = "testMachineId";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/"
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", err=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
+  });
+});

--- a/test/integration/connection-params-schedules.js
+++ b/test/integration/connection-params-schedules.js
@@ -8,7 +8,7 @@ const testPort = 9228;
 const Primus = require("primus");
 const msEndpoint = `http://localhost:${testPort}/messaging/`;
 
-describe("MS Connection : Integration", ()=>{
+describe("MS Connection : Schedules : Integration", ()=>{
   before(()=>{
     simple.mock(gcs, "init").returnWith();
     simple.mock(datastore, "initdb").returnWith();
@@ -20,10 +20,11 @@ describe("MS Connection : Integration", ()=>{
   });
 
   describe("With the messaging server under test running it...", ()=>{
-    it("prevents connections without a displayId", ()=>{
-      const displayId = "testId";
-      const machineId = "testMachineId";
-      const msUrl = `${msEndpoint}?XXXXdisplayId=${displayId}&machineId=${machineId}`;
+
+    it("prevents connections with scheduleId but without an endpointId", ()=>{
+      const scheduleId = "testId";
+      const endpointId = "testEndpointId";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&XXXXXXendpointId=${endpointId}`;
       console.log(`Connecting to websocket with ${msUrl}`);
 
       const ms = new (Primus.createSocket({
@@ -39,10 +40,10 @@ describe("MS Connection : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("prevents connections without a machineId", ()=>{
-      const displayId = "testId";
-      const machineId = "testMachineId";
-      const msUrl = `${msEndpoint}?displayId=${displayId}&XXXXXXmachineId=${machineId}`;
+    it("prevents connections with string undefined as a scheduleId", ()=>{
+      const scheduleId = "undefined";
+      const endpointId = "testEndpointId";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&endpointId=${endpointId}`;
       console.log(`Connecting to websocket with ${msUrl}`);
 
       const ms = new (Primus.createSocket({
@@ -58,10 +59,10 @@ describe("MS Connection : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("prevents connections with string undefined as a displayId", ()=>{
-      const displayId = "undefined";
-      const machineId = "testMachineId";
-      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+    it("prevents connections with string null as a scheduleId", ()=>{
+      const scheduleId = "null";
+      const endpointId = "testEndpointId";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&endpointId=${endpointId}`;
       console.log(`Connecting to websocket with ${msUrl}`);
 
       const ms = new (Primus.createSocket({
@@ -77,10 +78,10 @@ describe("MS Connection : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("prevents connections with string null as a displayId", ()=>{
-      const displayId = "null";
-      const machineId = "testMachineId";
-      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+    it("prevents connections with string undefined as an endpointId", ()=>{
+      const scheduleId = "testId";
+      const endpointId = "undefined";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&endpointId=${endpointId}`;
       console.log(`Connecting to websocket with ${msUrl}`);
 
       const ms = new (Primus.createSocket({
@@ -96,10 +97,10 @@ describe("MS Connection : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("prevents connections with string undefined as a machineId", ()=>{
-      const displayId = "testId";
-      const machineId = "undefined";
-      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+    it("prevents connections with string null as an endpointId", ()=>{
+      const scheduleId = "testId";
+      const endpointId = "null";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&endpointId=${endpointId}`;
       console.log(`Connecting to websocket with ${msUrl}`);
 
       const ms = new (Primus.createSocket({
@@ -115,31 +116,12 @@ describe("MS Connection : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("prevents connections with string null as a machineId", ()=>{
-      const displayId = "testId";
-      const machineId = "null";
-      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
-      console.log(`Connecting to websocket with ${msUrl}`);
+    it("allows a connection with proper schedule and endpoint ids", ()=>{
+      simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(true);
 
-      const ms = new (Primus.createSocket({
-        transformer: "websockets",
-        pathname: "messaging/primus/",
-        reconnect: {retries: 0}
-      }))(msUrl);
-
-      return new Promise((res, rej)=>{
-        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
-        ms.on("error", (err)=>{console.error(err.message); res()});
-      })
-      .then(()=>ms.end());
-    });
-
-    it("allows a connection with proper display and machine ids", ()=>{
-      simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
-
-      const displayId = "testId";
-      const machineId = "testMachineId";
-      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      const scheduleId = "testId";
+      const endpointId = "testEndpointId";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&endpointId=${endpointId}`;
       console.log(`Connecting to websocket with ${msUrl}`);
 
       const ms = new (Primus.createSocket({
@@ -154,12 +136,12 @@ describe("MS Connection : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("rejects a connection if display id is not valid", ()=>{
-      simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(false);
+    it("rejects a connection if schedule id is not valid", ()=>{
+      simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(false);
 
-      const displayId = "testId";
-      const machineId = "testMachineId";
-      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      const scheduleId = "testId";
+      const endpointId = "testEndpointId";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&endpointId=${endpointId}`;
       console.log(`Connecting to websocket with ${msUrl}`);
 
       const ms = new (Primus.createSocket({

--- a/test/manual/test.js
+++ b/test/manual/test.js
@@ -1,13 +1,21 @@
 const Primus = require("primus");
 const MS_PORT = process.env.MS_PORT;
+const SCHEDULE_ID = process.env.SCHEDULE_ID;
 const DISPLAY_ID = process.env.DISPLAY_ID || "test-manual";
 const endpoint = MS_PORT ? `http://localhost:${MS_PORT}` :
-      process.env.MS_STAGING ? "https://services-stage.risevision.com/" :
+      process.env.MS_STAGING ? "https://services-stage.risevision.com" :
       "https://services.risevision.com";
 
 const Socket = Primus.createSocket({transformer: "websockets", pathname: '/messaging/primus'});
 
-const connection = new Socket(`${endpoint}/messaging?displayId=${DISPLAY_ID}&machineId=1234`, {
+const urlParams = SCHEDULE_ID ?
+  `scheduleId=${SCHEDULE_ID}&endpointId=1234` :
+  `displayId=${DISPLAY_ID}&machineId=1234`;
+const url = `${endpoint}/messaging?${urlParams}`;
+
+console.log(`Connecting to ${ url }`);
+
+const connection = new Socket(url, {
   reconnect: {
     max: 600000,
     min: 5000,

--- a/test/manual/test.js
+++ b/test/manual/test.js
@@ -13,7 +13,7 @@ const urlParams = SCHEDULE_ID ?
   `displayId=${DISPLAY_ID}&machineId=1234`;
 const url = `${endpoint}/messaging?${urlParams}`;
 
-console.log(`Connecting to ${ url }`);
+console.log(`Connecting to ${url}`);
 
 const connection = new Socket(url, {
   reconnect: {


### PR DESCRIPTION
## Description
- Consider connection from schedule and endpoint id.
- Use schedule id instead of display id for data structures in case a display id was not provided but an schedule id was.
- Update manual tests to accound for schedule id scenario.
- No ban checks still implemented

## Motivation and Context
Messaging service now needs to support also connections related to an endpoint id / schedule id, with validation according to the design docs:

https://docs.google.com/document/d/1eKG9gKLxNT6_l22mvvVE6qgMaR4vQw079YtSePCYW8M/edit#
https://docs.google.com/document/d/1G4UcGtoHxLEpvoTXUi7bZ9Jo1-wLAF5d5kkU6uhKb4Q/edit#heading=h.2e5j3jrgtz0d ( schedule / display validation section )

If a scheduleId parameter is received, it will be validated and authorized as an endpointId/scheduleId connection; otherwise it will validated as a displayId/machineId connection ( as before ). This way, the current behavior is not affected by current PR changes.

## How Has This Been Tested?
Automated integration tests concernting new scheduleId/endpointId parameters were added.

Also, manual test script was modified to support an optional SCHEDULE_ID parameter that would switch a request to include scheduleId and endpointId parameters.

Calling this script using a valid schedule id worked as expected:

```
MS_STAGING=1 SCHEDULE_ID=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf&endpointId=1234
messaging service connected https://services-stage.risevision.com
```

and using an invalid schedule id resulted in errors, as expected:
```
MS_STAGING=1 SCHEDULE_ID=c0b41a3b-d07b-45c1-b8ed-3e1039b4ce node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=c0b41a3b-d07b-45c1-b8ed-3e1039b4ce&endpointId=1234
messaging error
{ Error: unexpected server response (404)
    at ClientRequest._req.on (/home/santiago/rise/messaging-service/node_modules/ws/lib/WebSocket.js:653:21)
```

Previous scenarios with displayId were also manually tested, and worked as expected.

## Release Plan:
This branch will be merged to parent feature/check_valid_displays branch. Production release as described on parent branch.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
-
