### PR TITLE
Feature/ban unban endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const app = express();
 const pubsubConnectorPOST = require("./src/webhooks/pubsub-connector/post-handler.js");
 const coreGET = require("./src/webhooks/core/get-handler");
 const coreIdUpdate = require("./src/webhooks/core/id-update-handler");
+const enpoints = require("./src/webhooks/endpoints/endpoint-handlers");
 const presencePOST = require("./src/webhooks/presence/post-handler");
 const presenceOPTIONS = require("./src/webhooks/presence/options-handler");
 const jsonParser = require("body-parser").json();
@@ -39,6 +40,8 @@ app.get("/", (req, res)=>res.end());
 
 app.get("/messaging/core", coreGET);
 app.get("/messaging/core/idUpdate", coreIdUpdate);
+app.get("/messaging/ban", enpoints.handleBan);
+app.get("/messaging/unban", enpoints.handleUnban);
 
 app.post("/messaging/pubsub", jsonParser, pubsubConnectorPOST);
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const app = express();
 const pubsubConnectorPOST = require("./src/webhooks/pubsub-connector/post-handler.js");
 const coreGET = require("./src/webhooks/core/get-handler");
 const coreIdUpdate = require("./src/webhooks/core/id-update-handler");
-const enpoints = require("./src/webhooks/endpoints/endpoint-handlers");
+const endpoints = require("./src/webhooks/endpoints/endpoint-handlers");
 const presencePOST = require("./src/webhooks/presence/post-handler");
 const presenceOPTIONS = require("./src/webhooks/presence/options-handler");
 const jsonParser = require("body-parser").json();
@@ -40,8 +40,8 @@ app.get("/", (req, res)=>res.end());
 
 app.get("/messaging/core", coreGET);
 app.get("/messaging/core/idUpdate", coreIdUpdate);
-app.get("/messaging/ban", enpoints.handleBan);
-app.get("/messaging/unban", enpoints.handleUnban);
+app.get("/messaging/ban", endpoints.handleBan);
+app.get("/messaging/unban", endpoints.handleUnban);
 
 app.post("/messaging/pubsub", jsonParser, pubsubConnectorPOST);
 

--- a/src/db/api.js
+++ b/src/db/api.js
@@ -262,11 +262,20 @@ module.exports = {
     removeScheduleId(id) {
       return redis.setRemove('valid-schedules', [id])
     },
+    banEndpointId(id, reason) {
+      return redis.patchHash('banned-endpoints', {[id]: reason})
+    },
+    unbanEndpointId(id) {
+      return redis.removeHashField('banned-endpoints', id)
+    },
     isValidDisplayId(displayId) {
       return redis.setHas('valid-displays', displayId)
     },
     isValidScheduleId(scheduleId) {
       return redis.setHas('valid-schedules', scheduleId)
+    },
+    isBannedEndpointId(endpointId) {
+      return redis.hashFieldExists('banned-endpoints', endpointId)
     }
   }
 };

--- a/src/db/redis/datastore.js
+++ b/src/db/redis/datastore.js
@@ -4,7 +4,7 @@ const gkeHostname = "display-ms-redis-master";
 const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : gkeHostname;
 
 let client = null;
-let promisified = ["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "smembers", "flushall", "sismember", "exists", "sunion", "scard"];
+let promisified = ["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "hexists", "smembers", "flushall", "sismember", "exists", "sunion", "scard"];
 
 module.exports = {
   initdb(dbclient = null) {
@@ -51,6 +51,9 @@ module.exports = {
   },
   patchHash(key, patchObj) {
     return promisified.hmset(key, patchObj);
+  },
+  hashFieldExists(key, field) {
+    return promisified.hexists(key, field);
   },
   quit(cb) {
     client.quit(cb);

--- a/src/webhooks/endpoints/endpoint-handlers.js
+++ b/src/webhooks/endpoints/endpoint-handlers.js
@@ -28,7 +28,9 @@ function invalidInput(req, resp) {
   if (!isAuthorized(req)) {
     return invalid(paramErrors.wrongAuthorization);
   }
-  if (!req.query.id) {return invalid(paramErrors.missingId);}
+  if (!req.query.id) {
+    return invalid(paramErrors.missingId);
+  }
 
   return false;
 }

--- a/src/webhooks/endpoints/endpoint-handlers.js
+++ b/src/webhooks/endpoints/endpoint-handlers.js
@@ -3,11 +3,13 @@ const paramErrors = require("./param-errors");
 const dbApi = require("../../db/api");
 const logger = require("../../logger");
 
+const serviceKey = 'TEST';
 const SERVER_ERROR = 500;
 
-function invalidInput({id} = {}, resp) {
+function invalidInput({id, sk} = {}, resp) {
   const invalid = invalidHandler.bind(null, resp);
 
+  if (sk !== serviceKey) {return invalid(paramErrors.wrongServiceKey);}
   if (!id) {return invalid(paramErrors.missingId);}
 
   return false;

--- a/src/webhooks/endpoints/endpoint-handlers.js
+++ b/src/webhooks/endpoints/endpoint-handlers.js
@@ -1,0 +1,53 @@
+const paramErrors = require("./param-errors");
+
+const dbApi = require("../../db/api");
+const logger = require("../../logger");
+
+const SERVER_ERROR = 500;
+
+function invalidInput({id} = {}, resp) {
+  const invalid = invalidHandler.bind(null, resp);
+
+  if (!id) {return invalid(paramErrors.missingId);}
+
+  return false;
+}
+
+function invalidHandler(resp, paramError) {
+  resp.status(paramError.code).send(paramError.msg);
+  return true;
+}
+
+function handleError(resp, error) {
+  return resp.status(SERVER_ERROR).send(error.message || 'server error');
+}
+
+function handleBan(req, resp) {
+  const {reason, id} = req.query;
+
+  logger.log(`Received ${id} ban request`);
+
+  if (invalidInput(req.query, resp)) {
+    return;
+  }
+
+  dbApi.validation.banEndpointId(id, reason || '')
+  .then(() => resp.send("Ban applied"))
+  .catch(error => handleError(resp, error));
+}
+
+function handleUnban(req, resp) {
+  const {id} = req.query;
+
+  logger.log(`Received ${id} unban request`);
+
+  if (invalidInput(req.query, resp)) {
+    return;
+  }
+
+  dbApi.validation.unbanEndpointId(id)
+  .then(() => resp.send("Unban applied"))
+  .catch(error => handleError(resp, error));
+}
+
+module.exports = {handleBan, handleUnban}

--- a/src/webhooks/endpoints/endpoint-handlers.js
+++ b/src/webhooks/endpoints/endpoint-handlers.js
@@ -3,7 +3,7 @@ const paramErrors = require("./param-errors");
 const dbApi = require("../../db/api");
 const logger = require("../../logger");
 
-const expectedAuthorizationKey = 'TEST';
+const expectedAuthorizationKey = 'TEST:';
 const SERVER_ERROR = 500;
 
 function isAuthorized(req) {

--- a/src/webhooks/endpoints/endpoint-handlers.js
+++ b/src/webhooks/endpoints/endpoint-handlers.js
@@ -26,7 +26,10 @@ function isAuthorized(req) {
 }
 
 function invalidInput(req, resp) {
-  const invalid = invalidHandler.bind(null, resp);
+  const invalid = paramError => {
+    resp.status(paramError.code).send(paramError.msg);
+    return true;
+  }
 
   if (!isAuthorized(req)) {
     return invalid(paramErrors.wrongAuthorization);
@@ -36,11 +39,6 @@ function invalidInput(req, resp) {
   }
 
   return false;
-}
-
-function invalidHandler(resp, paramError) {
-  resp.status(paramError.code).send(paramError.msg);
-  return true;
 }
 
 function handleError(resp, error) {

--- a/src/webhooks/endpoints/endpoint-handlers.js
+++ b/src/webhooks/endpoints/endpoint-handlers.js
@@ -3,7 +3,10 @@ const paramErrors = require("./param-errors");
 const dbApi = require("../../db/api");
 const logger = require("../../logger");
 
-const expectedAuthorizationKey = 'TEST:';
+const authorizationUser = process.env.NODE_ENV === "test" ?
+  "TEST" : process.env.WEBHOOK_AUTHORIZATION_KEY || String(Math.random());
+const expectedAuthorizationKey = `${authorizationUser}:`;
+
 const SERVER_ERROR = 500;
 
 function isAuthorized(req) {

--- a/src/webhooks/endpoints/param-errors.js
+++ b/src/webhooks/endpoints/param-errors.js
@@ -1,7 +1,7 @@
 module.exports = {
-  wrongServiceKey: {
+  wrongAuthorization: {
     code: 403,
-    msg: "Incorrect service key (sk)"
+    msg: "Not authorized"
   },
   missingId: {
     code: 400,

--- a/src/webhooks/endpoints/param-errors.js
+++ b/src/webhooks/endpoints/param-errors.js
@@ -1,4 +1,8 @@
 module.exports = {
+  wrongServiceKey: {
+    code: 403,
+    msg: "Incorrect service key (sk)"
+  },
   missingId: {
     code: 400,
     msg: "Endpoint or display id (id) is required"

--- a/src/webhooks/endpoints/param-errors.js
+++ b/src/webhooks/endpoints/param-errors.js
@@ -1,0 +1,6 @@
+module.exports = {
+  missingId: {
+    code: 400,
+    msg: "Endpoint or display id (id) is required"
+  }
+};

--- a/test/integration/db-api.js
+++ b/test/integration/db-api.js
@@ -201,7 +201,7 @@ describe("DB API : Integration", ()=>{
       .then(exists => assert(exists));
     });
 
-    it("should unban and endpointId", ()=>{
+    it("should unban an endpointId", ()=>{
       return dbApi.validation.banEndpointId('ENDPOINT_ID', 'REASON')
       .then(() => dbApi.validation.unbanEndpointId('ENDPOINT_ID'))
       .then(() => datastore.hashFieldExists('banned-endpoints', 'ENDPOINT_ID'))

--- a/test/integration/db-api.js
+++ b/test/integration/db-api.js
@@ -195,6 +195,19 @@ describe("DB API : Integration", ()=>{
       .then(exists => assert(!exists));
     });
 
+    it("should ban an endpointId", ()=>{
+      return dbApi.validation.banEndpointId('ENDPOINT_ID', 'REASON')
+      .then(() => datastore.hashFieldExists('banned-endpoints', 'ENDPOINT_ID'))
+      .then(exists => assert(exists));
+    });
+
+    it("should unban and endpointId", ()=>{
+      return dbApi.validation.banEndpointId('ENDPOINT_ID', 'REASON')
+      .then(() => dbApi.validation.unbanEndpointId('ENDPOINT_ID'))
+      .then(() => datastore.hashFieldExists('banned-endpoints', 'ENDPOINT_ID'))
+      .then(exists => assert(!exists));
+    });
+
     describe("isValidDisplayId", ()=>{
       it("identifies a valid display id", ()=>{
         return datastore.setAdd('valid-displays', ['ABCD'])
@@ -229,6 +242,25 @@ describe("DB API : Integration", ()=>{
         return dbApi.validation.isValidScheduleId('XHYZ')
         .then(isValid=>{
           assert(!isValid);
+        })
+      });
+    });
+
+    describe("isBannedEndpointId", ()=>{
+      it("identifies a banned endpoint id", ()=>{
+        return dbApi.validation.banEndpointId('ABCD')
+        .then(()=>
+          dbApi.validation.isBannedEndpointId('ABCD')
+          .then(isBanned=>{
+            assert(isBanned);
+          })
+        );
+      });
+
+      it("identifies a not banned endpoint id", ()=>{
+        return dbApi.validation.isBannedEndpointId('XHYZ')
+        .then(isBanned=>{
+          assert(!isBanned);
         })
       });
     });

--- a/test/integration/endpoint-ban-unban-hook.js
+++ b/test/integration/endpoint-ban-unban-hook.js
@@ -30,6 +30,22 @@ describe("Webhooks : enpoints", ()=>{
       });
     });
 
+    it("fails on invalid authorization", ()=>{
+      return rp({
+        method: "GET",
+        headers: {Authorization: 'Basic XXX'},
+        uri: `http://localhost:${testPort}/messaging/ban`,
+        json: true
+      })
+      .then(()=>{
+        assert.fail("Should have rejected");
+      })
+      .catch(err=>{
+        assert(err.message.includes("Not authorized"));
+        assert(err.statusCode === NOT_AUTHORIZED);
+      });
+    });
+
     it("expects id parameter", ()=>{
       return rp({
         method: "GET",
@@ -87,6 +103,22 @@ describe("Webhooks : enpoints", ()=>{
     it("expects Basic header", ()=>{
       return rp({
         method: "GET",
+        uri: `http://localhost:${testPort}/messaging/unban`,
+        json: true
+      })
+      .then(()=>{
+        assert.fail("Should have rejected");
+      })
+      .catch(err=>{
+        assert(err.message.includes("Not authorized"));
+        assert(err.statusCode === NOT_AUTHORIZED);
+      });
+    });
+
+    it("fails on invalid authorization", ()=>{
+      return rp({
+        method: "GET",
+        headers: {Authorization: 'Basic XXX'},
         uri: `http://localhost:${testPort}/messaging/unban`,
         json: true
       })

--- a/test/integration/endpoint-ban-unban-hook.js
+++ b/test/integration/endpoint-ban-unban-hook.js
@@ -10,7 +10,7 @@ const testPort = 9228;
 const BAD_REQUEST = 400;
 const NOT_AUTHORIZED = 403;
 
-const TEST_AUTHORIZATION = {Authorization: 'BASIC VEVTVDo='}
+const TEST_AUTHORIZATION = {Authorization: 'Basic VEVTVDo='}
 
 describe("Webhooks : enpoints", ()=>{
 

--- a/test/integration/endpoint-ban-unban-hook.js
+++ b/test/integration/endpoint-ban-unban-hook.js
@@ -1,0 +1,129 @@
+/* eslint-env mocha */
+
+const assert = require("assert");
+const rp = require("request-promise-native");
+const simple = require("simple-mock");
+
+const dbApi = require("../../src/db/api");
+
+const testPort = 9228;
+const BAD_REQUEST = 400;
+const NOT_AUTHORIZED = 403;
+
+describe("Webhooks : enpoints", ()=>{
+
+  describe("ban", ()=>{
+    it("expects sk parameter", ()=>{
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/ban`,
+        json: true
+      })
+      .then(()=>{
+        assert.fail("Should have rejected");
+      })
+      .catch(err=>{
+        assert(err.message.includes("sk"));
+        assert(err.statusCode === NOT_AUTHORIZED);
+      });
+    });
+
+    it("expects id parameter", ()=>{
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/ban?sk=TEST`,
+        json: true
+      })
+      .then(()=>{
+        assert.fail("Should have rejected");
+      })
+      .catch(err=>{
+        assert(err.message.includes("Endpoint or display id"));
+        assert(err.statusCode === BAD_REQUEST);
+      });
+    });
+
+    it("responds ok and bans id with empty reason", ()=>{
+      simple.mock(dbApi.validation, "banEndpointId").resolveWith();
+
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/ban?sk=TEST&id=1234`,
+        json: true
+      })
+      .then(()=>{
+        const stub = dbApi.validation.banEndpointId;
+
+        assert(stub.called);
+        assert.equal(stub.lastCall.args[0], '1234');
+        assert.equal(stub.lastCall.args[1], '');
+      });
+    });
+
+    it("responds ok and bans id with explicit reason", ()=>{
+      simple.mock(dbApi.validation, "banEndpointId").resolveWith();
+
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/ban?sk=TEST&id=1234&reason=Abuse`,
+        json: true
+      })
+      .then(()=>{
+        const stub = dbApi.validation.banEndpointId;
+
+        assert(stub.called);
+        assert.equal(stub.lastCall.args[0], '1234');
+        assert.equal(stub.lastCall.args[1], 'Abuse');
+      });
+    });
+  });
+
+  describe("unban", ()=>{
+    it("expects sk parameter", ()=>{
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/unban`,
+        json: true
+      })
+      .then(()=>{
+        assert.fail("Should have rejected");
+      })
+      .catch(err=>{
+        assert(err.message.includes("sk"));
+        assert(err.statusCode === NOT_AUTHORIZED);
+      });
+    });
+
+    it("expects id parameter", ()=>{
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/unban?sk=TEST`,
+        json: true
+      })
+      .then(()=>{
+        assert.fail("Should have rejected");
+      })
+      .catch(err=>{
+        assert(err.message.includes("Endpoint or display id"));
+        assert(err.statusCode === BAD_REQUEST);
+      });
+    });
+
+    it("responds ok and unbans id", ()=>{
+      simple.mock(dbApi.validation, "unbanEndpointId").resolveWith();
+
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/unban?sk=TEST&id=1234`,
+        json: true
+      })
+      .then(()=>{
+        const stub = dbApi.validation.unbanEndpointId;
+
+        assert(stub.called);
+        assert.equal(stub.lastCall.args[0], '1234');
+      });
+    });
+  });
+
+});

--- a/test/integration/endpoint-ban-unban-hook.js
+++ b/test/integration/endpoint-ban-unban-hook.js
@@ -10,10 +10,12 @@ const testPort = 9228;
 const BAD_REQUEST = 400;
 const NOT_AUTHORIZED = 403;
 
+const TEST_AUTHORIZATION = {Authorization: 'BASIC VEVTVA=='}
+
 describe("Webhooks : enpoints", ()=>{
 
   describe("ban", ()=>{
-    it("expects sk parameter", ()=>{
+    it("expects Basic header", ()=>{
       return rp({
         method: "GET",
         uri: `http://localhost:${testPort}/messaging/ban`,
@@ -23,7 +25,7 @@ describe("Webhooks : enpoints", ()=>{
         assert.fail("Should have rejected");
       })
       .catch(err=>{
-        assert(err.message.includes("sk"));
+        assert(err.message.includes("Not authorized"));
         assert(err.statusCode === NOT_AUTHORIZED);
       });
     });
@@ -31,7 +33,8 @@ describe("Webhooks : enpoints", ()=>{
     it("expects id parameter", ()=>{
       return rp({
         method: "GET",
-        uri: `http://localhost:${testPort}/messaging/ban?sk=TEST`,
+        headers: TEST_AUTHORIZATION,
+        uri: `http://localhost:${testPort}/messaging/ban`,
         json: true
       })
       .then(()=>{
@@ -48,7 +51,8 @@ describe("Webhooks : enpoints", ()=>{
 
       return rp({
         method: "GET",
-        uri: `http://localhost:${testPort}/messaging/ban?sk=TEST&id=1234`,
+        headers: TEST_AUTHORIZATION,
+        uri: `http://localhost:${testPort}/messaging/ban?id=1234`,
         json: true
       })
       .then(()=>{
@@ -65,7 +69,8 @@ describe("Webhooks : enpoints", ()=>{
 
       return rp({
         method: "GET",
-        uri: `http://localhost:${testPort}/messaging/ban?sk=TEST&id=1234&reason=Abuse`,
+        headers: TEST_AUTHORIZATION,
+        uri: `http://localhost:${testPort}/messaging/ban?id=1234&reason=Abuse`,
         json: true
       })
       .then(()=>{
@@ -79,7 +84,7 @@ describe("Webhooks : enpoints", ()=>{
   });
 
   describe("unban", ()=>{
-    it("expects sk parameter", ()=>{
+    it("expects Basic header", ()=>{
       return rp({
         method: "GET",
         uri: `http://localhost:${testPort}/messaging/unban`,
@@ -89,7 +94,7 @@ describe("Webhooks : enpoints", ()=>{
         assert.fail("Should have rejected");
       })
       .catch(err=>{
-        assert(err.message.includes("sk"));
+        assert(err.message.includes("Not authorized"));
         assert(err.statusCode === NOT_AUTHORIZED);
       });
     });
@@ -97,7 +102,8 @@ describe("Webhooks : enpoints", ()=>{
     it("expects id parameter", ()=>{
       return rp({
         method: "GET",
-        uri: `http://localhost:${testPort}/messaging/unban?sk=TEST`,
+        headers: TEST_AUTHORIZATION,
+        uri: `http://localhost:${testPort}/messaging/unban`,
         json: true
       })
       .then(()=>{
@@ -114,7 +120,8 @@ describe("Webhooks : enpoints", ()=>{
 
       return rp({
         method: "GET",
-        uri: `http://localhost:${testPort}/messaging/unban?sk=TEST&id=1234`,
+        headers: TEST_AUTHORIZATION,
+        uri: `http://localhost:${testPort}/messaging/unban?id=1234`,
         json: true
       })
       .then(()=>{

--- a/test/integration/endpoint-ban-unban-hook.js
+++ b/test/integration/endpoint-ban-unban-hook.js
@@ -10,7 +10,7 @@ const testPort = 9228;
 const BAD_REQUEST = 400;
 const NOT_AUTHORIZED = 403;
 
-const TEST_AUTHORIZATION = {Authorization: 'BASIC VEVTVA=='}
+const TEST_AUTHORIZATION = {Authorization: 'BASIC VEVTVDo='}
 
 describe("Webhooks : enpoints", ()=>{
 

--- a/test/unit/file-update-handler.js
+++ b/test/unit/file-update-handler.js
@@ -18,7 +18,7 @@ describe("Pub/sub Update", ()=>{
   const watchers = ["d1", "d2"];
 
   before(() => {
-    redis.initdb(["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "smembers", "flushall", "sismember", "exists", "sunion", "scard"]
+    redis.initdb(["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "hexists", "smembers", "flushall", "sismember", "exists", "sunion", "scard"]
     .reduce((obj, el)=>{
       return Object.assign(obj, {[el]: simple.stub().callbackWith(null, "ok")});
     }, {

--- a/test/unit/redis/datastore.js
+++ b/test/unit/redis/datastore.js
@@ -5,7 +5,7 @@ const simple = require("simple-mock");
 
 describe("REDIS", ()=>{
   before("mock", ()=>{
-    redis.initdb(["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "smembers", "flushall", "sismember", "exists"]
+    redis.initdb(["get", "del", "set", "sadd", "srem", "hmset", "hgetall", "hdel", "hexists", "smembers", "flushall", "sismember", "exists"]
     .reduce((obj, el)=>{
       return Object.assign(obj, {[el]: simple.stub().callbackWith(null, "ok")});
     }, {}));


### PR DESCRIPTION
## Description
Ban / unban endpoint ids
- /messaging/ban
- /messaging/unban

Validation based on banned endpoints comes later in a separate PR.

## Motivation and Context
As described here:
https://docs.google.com/document/d/1aZBZ_E6CSQWQXvgb-o0mM9WmOKPLXiad9hU-Tet-m3Y/edit

## How Has This Been Tested?
Automated tests were created for the new API functions and endpoint call scenarios.
Tested manually on staging using CURL calls with basic authentication:

Ban:
```
curl -u TEST "https://services-stage.risevision.com/messaging/ban?id=test22&reason=Abuse"
Enter host password for user 'TEST': <empty>
Ban applied
```

Checking directly on the Redis node:
```
redis-cli HGET banned-endpoints test22
"Abuse"
```

Unban:
```
curl -u TEST "https://see.risevision.com/messaging/unban?id=test22"
Enter host password for user 'TEST': <empty>
Unban applied
```

Checking directly on the Redis node:
```
redis-cli HGET banned-endpoints test22
(nil)
```

## Release Plan:
To be released to parent branch, and likely Wednesday or Thursday to production with the rest of the changes. This new functionality should not affect existing one, as it's a new webhook.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Same as parent branch.
