### PR TITLE
Feature/validate banned endpoints displays

### DIFF
--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -41,7 +41,7 @@ const authorizeSchedule = (scheduleId, endpointId, done) => {
       });
     }
 
-    return checkBanned('endpoint', endpointId, done);
+    checkBanned('endpoint', endpointId, done);
   });
 }
 
@@ -64,7 +64,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
       });
     }
 
-    return checkBanned('display', displayId, done);
+    checkBanned('display', displayId, done);
   });
 }
 

--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -7,6 +7,21 @@ const handlers = require("../event-handlers/messages");
 
 const invalidIds = ["undefined", "null"];
 
+const checkBanned = (type, id, done) => {
+  dbApi.validation.isBannedEndpointId(id)
+  .then(isBanned => {
+    if (isBanned) {
+      logger.log(`Banned ${type} id (${type}Id: ${id})`);
+      return done({
+        statusCode: 403,
+        message: "banned"
+      });
+    }
+
+    done();
+  });
+}
+
 const authorizeSchedule = (scheduleId, endpointId, done) => {
   if (!scheduleId || !endpointId || [scheduleId, endpointId].some(id=>invalidIds.includes(id))) {
     logger.log(`Missing connection parameters (scheduleId: ${scheduleId}, endpointId: ${endpointId})`);
@@ -26,7 +41,7 @@ const authorizeSchedule = (scheduleId, endpointId, done) => {
       });
     }
 
-    done();
+    return checkBanned('endpoint', endpointId, done);
   });
 }
 
@@ -49,7 +64,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
       });
     }
 
-    done();
+    return checkBanned('display', displayId, done);
   });
 }
 

--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -14,7 +14,7 @@ const checkBanned = (type, id, done) => {
       logger.log(`Banned ${type} id (${type}Id: ${id})`);
       return done({
         statusCode: 403,
-        message: "banned"
+        message: "Unauthorized"
       });
     }
 

--- a/test/integration/connection-params-displays.js
+++ b/test/integration/connection-params-displays.js
@@ -175,5 +175,26 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
+    it("rejects a connection if display id is banned", ()=>{
+      simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
+      simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
+
+      const displayId = "testId";
+      const machineId = "testMachineId";
+      const msUrl = `${msEndpoint}?displayId=${displayId}&machineId=${machineId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/"
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", err=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
+
   });
 });

--- a/test/integration/connection-params-displays.js
+++ b/test/integration/connection-params-displays.js
@@ -136,6 +136,7 @@ describe("MS Connection : displays : Integration", ()=>{
 
     it("allows a connection with proper display and machine ids", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
+      simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(false);
 
       const displayId = "testId";
       const machineId = "testMachineId";

--- a/test/integration/connection-params-schedules.js
+++ b/test/integration/connection-params-schedules.js
@@ -156,5 +156,26 @@ describe("MS Connection : Schedules : Integration", ()=>{
       })
       .then(()=>ms.end());
     });
+
+    it("rejects a connection if and endpoint id is banned", ()=>{
+      simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(true);
+      simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
+
+      const scheduleId = "testId";
+      const endpointId = "testEndpointId";
+      const msUrl = `${msEndpoint}?scheduleId=${scheduleId}&endpointId=${endpointId}`;
+      console.log(`Connecting to websocket with ${msUrl}`);
+
+      const ms = new (Primus.createSocket({
+        transformer: "websockets",
+        pathname: "messaging/primus/"
+      }))(msUrl);
+
+      return new Promise((res, rej)=>{
+        ms.on("open", ()=>rej(Error("Should not have allowed the connection")));
+        ms.on("error", err=>{console.error(err.message); res()});
+      })
+      .then(()=>ms.end());
+    });
   });
 });

--- a/test/integration/connection-params-schedules.js
+++ b/test/integration/connection-params-schedules.js
@@ -118,6 +118,7 @@ describe("MS Connection : Schedules : Integration", ()=>{
 
     it("allows a connection with proper schedule and endpoint ids", ()=>{
       simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(true);
+      simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(false);
 
       const scheduleId = "testId";
       const endpointId = "testEndpointId";


### PR DESCRIPTION
## Description
Check if a display id or and endpoint id is in the banned list. If so, reject the connection with a 403 HTTP status; if not, continue as usual.

Endpoint and display ids are checked against the banned endpoint list.

## Motivation and Context
Banned functionality as described here:
https://docs.google.com/document/d/1G4UcGtoHxLEpvoTXUi7bZ9Jo1-wLAF5d5kkU6uhKb4Q/edit#heading=h.2e5j3jrgtz0d

## How Has This Been Tested?
Automated tests were created to validate banned ids are rejected.

Manual test for endpoint ids:

- First check that a valid schedule connects successfully:

```
MS_STAGING=1 SCHEDULE_ID=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf&endpointId=1234
messaging service connected https://services-stage.risevision.com
```

- Then ban the endpoint id ( fixed to '1234' on the manual tester ) and verify it fails with an HTTP 403 status:

```
curl -u TEST "https://services-stage.risevision.com/messaging/ban?id=1234&reason=Abuse"

MS_STAGING=1 SCHEDULE_ID=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf&endpointId=1234
messaging error
{ Error: unexpected server response (403)
    at ClientRequest._req.on (/home/santiago/rise/messaging-service/node_modules/ws/lib/WebSocket.js:653:21)
```

- Then unban it and verify it connects again:

```
curl -u TEST "https://services-stage.risevision.com/messaging/unban?id=1234"

MS_STAGING=1 SCHEDULE_ID=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=c0b41a3b-d07b-45c1-b8ed-3e1039b4ceaf&endpointId=1234
messaging service connected https://services-stage.risevision.com
```

Manual test for display ids:

- Again, first check that a valid display id connects:

```
MS_STAGING=1 DISPLAY_ID=8MZCC6AWXXGV node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?displayId=8MZCC6AWXXGV&machineId=1234
messaging service connected https://services-stage.risevision.com
```

Then ban the display id, and verify it can't connect any longer, and it was rejected with HTTP 403 status:

```
curl -u TEST "https://services-stage.risevision.com/messaging/ban?id=8MZCC6AWXXGV&reason=Abuse"

MS_STAGING=1 DISPLAY_ID=8MZCC6AWXXGV node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?displayId=8MZCC6AWXXGV&machineId=1234
messaging error
{ Error: unexpected server response (403)
    at ClientRequest._req.on (/home/santiago/rise/messaging-service/node_modules/ws/lib/WebSocket.js:653:21)
```

Finally unban it, and verify connection again:

```
curl -u TEST "https://services-stage.risevision.com/messaging/unban?id=8MZCC6AWXXGV"

MS_STAGING=1 DISPLAY_ID=8MZCC6AWXXGV node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?displayId=8MZCC6AWXXGV&machineId=1234
messaging service connected https://services-stage.risevision.com
```

## Release Plan:
To be released to production as the final step of the MS release ( see deployment card ), so this won't still be merged to parent branch.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
