### PR TITLE
Chore/disable display verification

### DIFF
--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -54,7 +54,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
     });
   }
 
-  /* dbApi.validation.isValidDisplayId(displayId)
+  dbApi.validation.isValidDisplayId(displayId)
   .then(isValid => {
     if (!isValid) {
       logger.log(`Invalid display id (displayId: ${displayId})`);
@@ -65,8 +65,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
     }
 
     checkBanned('display', displayId, done);
-  }); */
-  done();
+  });
 }
 
 module.exports = {

--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -1,13 +1,13 @@
 const logger = require("../logger");
 const querystring = require("querystring");
 const url = require("url");
-const dbApi = require("../db/api");
+// const dbApi = require("../db/api");
 const displayConnections = require("../event-handlers/display-connections");
 const handlers = require("../event-handlers/messages");
 
 const invalidIds = ["undefined", "null"];
 
-const checkBanned = (type, id, done) => {
+/* const checkBanned = (type, id, done) => {
   dbApi.validation.isBannedEndpointId(id)
   .then(isBanned => {
     if (isBanned) {
@@ -20,7 +20,7 @@ const checkBanned = (type, id, done) => {
 
     done();
   });
-}
+} */
 
 const authorizeSchedule = (scheduleId, endpointId, done) => {
   if (!scheduleId || !endpointId || [scheduleId, endpointId].some(id=>invalidIds.includes(id))) {
@@ -31,7 +31,7 @@ const authorizeSchedule = (scheduleId, endpointId, done) => {
     });
   }
 
-  dbApi.validation.isValidScheduleId(scheduleId)
+  /* dbApi.validation.isValidScheduleId(scheduleId)
   .then(isValid => {
     if (!isValid) {
       logger.log(`Invalid schedule id (scheduleId: ${scheduleId})`);
@@ -42,7 +42,8 @@ const authorizeSchedule = (scheduleId, endpointId, done) => {
     }
 
     checkBanned('endpoint', endpointId, done);
-  });
+  }); */
+  done();
 }
 
 const authorizeDisplay = (displayId, machineId, done) => {
@@ -54,7 +55,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
     });
   }
 
-  dbApi.validation.isValidDisplayId(displayId)
+  /* dbApi.validation.isValidDisplayId(displayId)
   .then(isValid => {
     if (!isValid) {
       logger.log(`Invalid display id (displayId: ${displayId})`);
@@ -65,7 +66,8 @@ const authorizeDisplay = (displayId, machineId, done) => {
     }
 
     checkBanned('display', displayId, done);
-  });
+  }); */
+  done();
 }
 
 module.exports = {

--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -54,7 +54,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
     });
   }
 
-  dbApi.validation.isValidDisplayId(displayId)
+  /* dbApi.validation.isValidDisplayId(displayId)
   .then(isValid => {
     if (!isValid) {
       logger.log(`Invalid display id (displayId: ${displayId})`);
@@ -65,7 +65,8 @@ const authorizeDisplay = (displayId, machineId, done) => {
     }
 
     checkBanned('display', displayId, done);
-  });
+  }); */
+  done();
 }
 
 module.exports = {

--- a/test/integration/connection-params-displays.js
+++ b/test/integration/connection-params-displays.js
@@ -155,7 +155,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    xit("rejects a connection if display id is not valid", ()=>{
+    it("rejects a connection if displayid is not valid", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(false);
 
       const displayId = "testId";
@@ -175,7 +175,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    xit("rejects a connection if display id is banned", ()=>{
+    it("rejects a connection if display id is banned", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
       simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
 

--- a/test/integration/connection-params-displays.js
+++ b/test/integration/connection-params-displays.js
@@ -155,7 +155,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("rejects a connection if displayid is not valid", ()=>{
+    xit("rejects a connection if displayid is not valid", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(false);
 
       const displayId = "testId";
@@ -175,7 +175,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("rejects a connection if display id is banned", ()=>{
+    xit("rejects a connection if display id is banned", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
       simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
 

--- a/test/integration/connection-params-displays.js
+++ b/test/integration/connection-params-displays.js
@@ -155,7 +155,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("rejects a connection if display id is not valid", ()=>{
+    xit("rejects a connection if display id is not valid", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(false);
 
       const displayId = "testId";
@@ -175,7 +175,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("rejects a connection if display id is banned", ()=>{
+    xit("rejects a connection if display id is banned", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
       simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
 

--- a/test/integration/connection-params-schedules.js
+++ b/test/integration/connection-params-schedules.js
@@ -137,7 +137,7 @@ describe("MS Connection : Schedules : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("rejects a connection if schedule id is not valid", ()=>{
+    xit("rejects a connection if schedule id is not valid", ()=>{
       simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(false);
 
       const scheduleId = "testId";
@@ -157,7 +157,7 @@ describe("MS Connection : Schedules : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    it("rejects a connection if and endpoint id is banned", ()=>{
+    xit("rejects a connection if and endpoint id is banned", ()=>{
       simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(true);
       simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
 


### PR DESCRIPTION
## Description
Disabling both display id and schedule id validation and ban checks.

## Motivation and Context
We are disabling these until persistence is enabled for MS production.

## How Has This Been Tested?
I tested invalid display and scheduled ids on tester, and they could connect ok ( again ).

## Release Plan:
To be released immediately.

#### Release Checklist Items Skipped?
No need to notify support, or update documentation.
