### PR TITLE
Prevented publishing to pubsub when displayId has a prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # redis dump
 dump.rdb
+
+/.project

--- a/src/google-pubsub/index.js
+++ b/src/google-pubsub/index.js
@@ -38,9 +38,11 @@ const retrySettings = {
 }; /* eslint no-magic-numbers: "off", no-multi-spaces: "off" */
 module.exports = {
   publishDisconnection(displayId) {
+    if (displayId && displayId.startsWith("content-sentinel-")) {return;}
     module.exports.publish(messageObject(displayId, "disconnected"));
   },
   publishConnection(displayId) {
+    if (displayId && displayId.startsWith("content-sentinel-")) {return;}
     module.exports.publish(messageObject(displayId, "connected"));
   },
   publish(msg = {}, topic = topicPath) {

--- a/test/unit/google-pubsub.js
+++ b/test/unit/google-pubsub.js
@@ -31,7 +31,7 @@ describe("Google PubSub", ()=>{
 
       googlePubSub.publishConnection(testId);
 
-      assert(!publishStub.lastCall.args[0]);
+      assert(!publishStub.callCount);
   });
 
   it("publishes message on display disconnection", ()=>{
@@ -51,6 +51,6 @@ describe("Google PubSub", ()=>{
 
       googlePubSub.publishDisconnection(testId);
 
-      assert(!publishStub.lastCall.args[0]);
+      assert(!publishStub.callCount);
   });
 });

--- a/test/unit/google-pubsub.js
+++ b/test/unit/google-pubsub.js
@@ -26,15 +26,31 @@ describe("Google PubSub", ()=>{
     assert.deepEqual(publishedMessage.status, expectedStatus);
   });
 
+  it("does not publish message on display connection with prefix", ()=>{
+      const testId = "content-sentinel-test-id";
+
+      googlePubSub.publishConnection(testId);
+
+      assert(!publishStub.lastCall.args[0]);
+  });
+
   it("publishes message on display disconnection", ()=>{
     const expectedStatus = "disconnected"
     const testId = "test-id";
 
-    googlePubSub.publishDisconnection("test-id");
+    googlePubSub.publishDisconnection(testId);
 
     const publishedMessage = JSON.parse(publishStub.lastCall.args[0].messages[0].data.toString());
 
     assert.deepEqual(publishedMessage.id, testId);
     assert.deepEqual(publishedMessage.status, expectedStatus);
+  });
+
+  it("does not publish message on display disconnection with prefix", ()=>{
+      const testId = "content-sentinel-test-id";
+
+      googlePubSub.publishDisconnection(testId);
+
+      assert(!publishStub.lastCall.args[0]);
   });
 });


### PR DESCRIPTION
## Description
Prevented publishing to pubsub when displayId has a prefix.

## Motivation and Context
This is a part of the ongoing epic implementation.

## How Has This Been Tested?
Unit tests.

## Reminder Checklist

 [] Messaging service stage environment is validated to still be working the same as prod

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
