### PR TITLE
Support for watch/unwatch/folder-watch/watchlist-compare requests via HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 dump.rdb
 
 /.project
+

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const pubsubConnectorPOST = require("./src/webhooks/pubsub-connector/post-handle
 const coreGET = require("./src/webhooks/core/get-handler");
 const coreIdUpdate = require("./src/webhooks/core/id-update-handler");
 const endpoints = require("./src/webhooks/endpoints/endpoint-handlers");
+const direct = require("./src/webhooks/endpoints/direct");
 const presencePOST = require("./src/webhooks/presence/post-handler");
 const presenceOPTIONS = require("./src/webhooks/presence/options-handler");
 const jsonParser = require("body-parser").json();
@@ -42,6 +43,7 @@ app.get("/messaging/core", coreGET);
 app.get("/messaging/core/idUpdate", coreIdUpdate);
 app.get("/messaging/ban", endpoints.handleBan);
 app.get("/messaging/unban", endpoints.handleUnban);
+app.get("/messaging/direct", direct);
 
 app.post("/messaging/pubsub", jsonParser, pubsubConnectorPOST);
 

--- a/src/event-handlers/messages/folder-watch.js
+++ b/src/event-handlers/messages/folder-watch.js
@@ -10,7 +10,7 @@ module.exports = {
       data.topic && data.topic.toUpperCase() === "WATCH" &&
       data.filePath && data.filePath.endsWith("/");
   },
-  doOnIncomingPod({filePath: folderPath, displayId} = {}) {
+  doOnIncomingPod({filePath: folderPath, displayId} = {}, resp) {
     return folders.watchingFolder(folderPath)
     .then(watching=>{
       return watching ? existingFolder(folderPath) : newFolder(folderPath);
@@ -32,13 +32,16 @@ module.exports = {
     })
     .then((folderData)=>{
       return watchList.lastChanged(displayId)
-      .then(watchlistLastChanged =>
-        displayConnections.sendMessage(displayId, {
+      .then(watchlistLastChanged => {
+        const message = {
           msg: "ok",
           topic: "watch-result",
           folderData,
           watchlistLastChanged
-        }));
+        };
+
+        return resp ? resp.send(message) : displayConnections.sendMessage(displayId, message);
+      })
     })
     .catch((err)=>{
       watchError(err, folderPath, displayId);

--- a/src/event-handlers/messages/unwatch.js
+++ b/src/event-handlers/messages/unwatch.js
@@ -8,7 +8,7 @@ module.exports = {
       data.topic && data.topic.toUpperCase() === "UNWATCH" &&
       data.filePaths;
   },
-  doOnIncomingPod(data) {
+  doOnIncomingPod(data, resp) {
     const {displayId, filePaths} = data;
 
     logger.log(`Unwatch ${displayId} ${filePaths.join(',')}`);
@@ -19,7 +19,7 @@ module.exports = {
           topic: "unwatch-result"
         };
 
-        return displayConnections.sendMessage(displayId, message);
+        return resp ? resp.send(message) : displayConnections.sendMessage(displayId, message);
       })
     .catch(error => console.error(displayId, error));
   }

--- a/src/event-handlers/messages/watch.js
+++ b/src/event-handlers/messages/watch.js
@@ -59,7 +59,7 @@ module.exports = {
       });
     })
     .catch((err)=>{
-      watchError(err, filePath, newEntry.displayId);
+      return watchError(err, filePath, newEntry.displayId, resp);
     });
   }
 };

--- a/src/event-handlers/messages/watchlist-compare.js
+++ b/src/event-handlers/messages/watchlist-compare.js
@@ -8,7 +8,7 @@ module.exports = {
       data.topic && data.topic.toUpperCase() === "WATCHLIST-COMPARE" &&
       data.lastChanged;
   },
-  doOnIncomingPod(data) {
+  doOnIncomingPod(data, resp) {
     const {displayId, lastChanged} = data;
 
     return db.watchList.lastChanged(displayId)
@@ -23,7 +23,7 @@ module.exports = {
           lastChanged: msLastChanged
         };
 
-        return displayConnections.sendMessage(displayId, message);
+        return resp ? resp.send(message) : displayConnections.sendMessage(displayId, message);
       })
     })
     .catch(error => console.error(displayId, error));

--- a/src/event-handlers/watch-error.js
+++ b/src/event-handlers/watch-error.js
@@ -1,14 +1,19 @@
 const displayConnections = require("./display-connections");
 
-module.exports = function(err = {}, filePath, displayId) {
+const SERVER_ERROR = 500;
+
+module.exports = function(err = {}, filePath, displayId, resp) { // eslint-disable-line max-params
   console.error(`[${err.message}] [${filePath}] [${displayId}]`);
 
-  displayConnections.sendMessage(displayId, {
+  const message = {
     error: err.message,
     errorMsg: err.message,
     errorCode: err.code,
     topic: "watch-result",
     filePath,
     msg: `There was an error processing WATCH:${err.message}`
-  });
+  };
+
+  return resp ? resp.status(SERVER_ERROR).send(message) : displayConnections.sendMessage(displayId, message);
 }
+

--- a/src/webhooks/endpoints/direct.js
+++ b/src/webhooks/endpoints/direct.js
@@ -3,7 +3,7 @@ const paramErrors = require("./param-errors");
 const handlers = require("../../event-handlers/messages");
 // const dbApi = require("../db/api");
 
-const validTopics = ["watch", "unwatch", "watchlist-compare"];
+const validTopics = ["WATCH", "UNWATCH", "WATCHLIST-COMPARE"];
 
 module.exports = (req, resp) => {
   const {topic, endpointId} = req.query;
@@ -27,7 +27,7 @@ function invalidInput({topic, endpointId, scheduleId, displayId} = {}, resp) { /
   const invalid = invalidHandler.bind(null, resp);
 
   if (!topic) {return invalid(paramErrors.missingTopic);}
-  if (!validTopics.includes(topic)) {return invalid(paramErrors.invalidTopic);}
+  if (!validTopics.includes(topic.toUpperCase())) {return invalid(paramErrors.invalidTopic);}
   if (!endpointId) {return invalid(paramErrors.missingEndpointId);}
   if (!scheduleId) {return invalid(paramErrors.missingScheduleId);}
   if (displayId) {return invalid(paramErrors.displaysNotAllowed);}

--- a/src/webhooks/endpoints/direct.js
+++ b/src/webhooks/endpoints/direct.js
@@ -12,8 +12,8 @@ module.exports = (req, resp) => {
   const eventHandler = handlers.getHandler(req.query);
   if (!eventHandler) {return invalidHandler(resp, paramErrors.noHandler);}
 
-  eventHandler.doOnIncomingPod(req.query, resp);
-  logger.log(`Request from Viewer id=${displayId} processed.`);
+  return eventHandler.doOnIncomingPod(req.query, resp)
+  .then(()=>logger.log(`Request from Viewer id=${displayId} processed.`));
 }
 
 function invalidInput({topic, displayId} = {}, resp) { // eslint-disable-line max-statements

--- a/src/webhooks/endpoints/direct.js
+++ b/src/webhooks/endpoints/direct.js
@@ -3,6 +3,8 @@ const paramErrors = require("./param-errors");
 const handlers = require("../../event-handlers/messages");
 // const dbApi = require("../db/api");
 
+const validTopics = ["watch", "unwatch", "watchlist-compare"];
+
 module.exports = (req, resp) => {
   const {topic, endpointId} = req.query;
 
@@ -25,6 +27,7 @@ function invalidInput({topic, endpointId, scheduleId, displayId} = {}, resp) { /
   const invalid = invalidHandler.bind(null, resp);
 
   if (!topic) {return invalid(paramErrors.missingTopic);}
+  if (!validTopics.includes(topic)) {return invalid(paramErrors.invalidTopic);}
   if (!endpointId) {return invalid(paramErrors.missingEndpointId);}
   if (!scheduleId) {return invalid(paramErrors.missingScheduleId);}
   if (displayId) {return invalid(paramErrors.displaysNotAllowed);}

--- a/src/webhooks/endpoints/direct.js
+++ b/src/webhooks/endpoints/direct.js
@@ -1,26 +1,33 @@
 const logger = require("../../logger");
 const paramErrors = require("./param-errors");
 const handlers = require("../../event-handlers/messages");
+// const dbApi = require("../db/api");
 
 module.exports = (req, resp) => {
-  const {topic, displayId} = req.query;
+  const {topic, endpointId} = req.query;
 
-  logger.log(`Received ${topic} request from Viewer id=${displayId}`);
+  logger.log(`Received ${topic} request from Viewer id=${endpointId}`);
 
   if (invalidInput(req.query, resp)) {return;}
+
+//  checkAuthorization(req.query, endpointId, resp);
+
+  req.query.displayId = req.query.endpointId;
 
   const eventHandler = handlers.getHandler(req.query);
   if (!eventHandler) {return invalidHandler(resp, paramErrors.noHandler);}
 
   return eventHandler.doOnIncomingPod(req.query, resp)
-  .then(()=>logger.log(`Request from Viewer id=${displayId} processed.`));
+  .then(()=>logger.log(`Request from Viewer id=${endpointId} processed.`));
 }
 
-function invalidInput({topic, displayId} = {}, resp) { // eslint-disable-line max-statements
+function invalidInput({topic, endpointId, scheduleId, displayId} = {}, resp) { // eslint-disable-line max-statements
   const invalid = invalidHandler.bind(null, resp);
 
   if (!topic) {return invalid(paramErrors.missingTopic);}
-  if (!displayId) {return invalid(paramErrors.missingDisplayId);}
+  if (!endpointId) {return invalid(paramErrors.missingEndpointId);}
+  if (!scheduleId) {return invalid(paramErrors.missingScheduleId);}
+  if (displayId) {return invalid(paramErrors.displaysNotAllowed);}
 
   return false;
 }
@@ -29,3 +36,25 @@ function invalidHandler(resp, paramError) {
   resp.status(paramError.code).send(paramError.msg);
   return true;
 }
+/*
+function checkAuthorization({endpointId, scheduleId} = {}, resp) {
+
+  const invalid = invalidHandler.bind(null, resp);
+
+  dbApi.validation.isValidScheduleId(scheduleId)
+  .then(isValid => {
+    if (!isValid) {
+      logger.log(`Invalid schedule id (scheduleId: ${scheduleId})`);
+      return invalid(paramErrors.invalidSchedule);
+    }
+  });
+
+  dbApi.validation.isBannedEndpointId(endpointId)
+  .then(isBanned => {
+    if (isBanned) {
+      logger.log(`Banned endpoint (id: ${endpointId})`);
+      return invalid(paramErrors.bannedEndpoint);
+    }
+  });
+}
+*/

--- a/src/webhooks/endpoints/direct.js
+++ b/src/webhooks/endpoints/direct.js
@@ -1,0 +1,31 @@
+const logger = require("../../logger");
+const paramErrors = require("./param-errors");
+const handlers = require("../../event-handlers/messages");
+
+module.exports = (req, resp) => {
+  const {topic, displayId} = req.query;
+
+  logger.log(`Received ${topic} request from Viewer id=${displayId}`);
+
+  if (invalidInput(req.query, resp)) {return;}
+
+  const eventHandler = handlers.getHandler(req.query);
+  if (!eventHandler) {return invalidHandler(resp, paramErrors.noHandler);}
+
+  eventHandler.doOnIncomingPod(req.query, resp);
+  logger.log(`Request from Viewer id=${displayId} processed.`);
+}
+
+function invalidInput({topic, displayId} = {}, resp) { // eslint-disable-line max-statements
+  const invalid = invalidHandler.bind(null, resp);
+
+  if (!topic) {return invalid(paramErrors.missingTopic);}
+  if (!displayId) {return invalid(paramErrors.missingDisplayId);}
+
+  return false;
+}
+
+function invalidHandler(resp, paramError) {
+  resp.status(paramError.code).send(paramError.msg);
+  return true;
+}

--- a/src/webhooks/endpoints/param-errors.js
+++ b/src/webhooks/endpoints/param-errors.js
@@ -11,11 +11,30 @@ module.exports = {
     code: 400,
     msg: "Display id (displayId) is required"
   },
+  displaysNotAllowed: {
+    code: 403,
+    msg: "Displays are not allowed"
+  },
+  missingEndpointId: {
+    code: 400,
+    msg: "Endpoint id (endpointId) is required"
+  },
+  missingScheduleId: {
+    code: 400,
+    msg: "Schedule id (scheduleId) is required"
+  },
   missingTopic: {
     code: 400,
     msg: "Topic (topic) is required"
   },
-
+  invalidSchedule: {
+    code: 404,
+    msg: "Schedule is not valid"
+  },
+  bannedEndpoint: {
+    code: 403,
+    msg: "Endpoint is banned"
+  },
   noHandler: {
     code: 400,
     msg: "Request has no handler"

--- a/src/webhooks/endpoints/param-errors.js
+++ b/src/webhooks/endpoints/param-errors.js
@@ -6,5 +6,18 @@ module.exports = {
   missingId: {
     code: 400,
     msg: "Endpoint or display id (id) is required"
+  },
+  missingDisplayId: {
+    code: 400,
+    msg: "Display id (displayId) is required"
+  },
+  missingTopic: {
+    code: 400,
+    msg: "Topic (topic) is required"
+  },
+
+  noHandler: {
+    code: 400,
+    msg: "Request has no handler"
   }
 };

--- a/src/webhooks/endpoints/param-errors.js
+++ b/src/webhooks/endpoints/param-errors.js
@@ -35,6 +35,10 @@ module.exports = {
     code: 403,
     msg: "Endpoint is banned"
   },
+  invalidTopic: {
+    code: 403,
+    msg: "Topic is not valid"
+  },
   noHandler: {
     code: 400,
     msg: "Request has no handler"

--- a/src/webhooks/pubsub-connector/post-handler.js
+++ b/src/webhooks/pubsub-connector/post-handler.js
@@ -9,6 +9,6 @@ module.exports = (req, resp) => {
     return resp.send("");
   }
 
-  fileUpdateHandler.doOnIncomingPod(req.body);
+  fileUpdateHandler.doOnIncomingPod(req.body, null);
   resp.send("");
 }

--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -117,7 +117,7 @@ module.exports = {
         const fullData = {...data, ...spark.query};
         const dataHandler = handlers.getHandler(fullData);
 
-        return dataHandler && dataHandler.doOnIncomingPod(fullData);
+        return dataHandler && dataHandler.doOnIncomingPod(fullData, null);
       });
     });
   }

--- a/test/integration/direct-request-hook.js
+++ b/test/integration/direct-request-hook.js
@@ -44,7 +44,9 @@ describe("Direct HTTP request", ()=>{
   });
 
   it("responds ok and calls event handler for watch", ()=>{
-    simple.mock(watchRequest, "doOnIncomingPod").returnWith();
+    simple.mock(watchRequest, "doOnIncomingPod").callFn((query, resp)=>{
+      resp.send();
+    });
     return rp({
       method: "GET",
       uri: `http://localhost:${testPort}/messaging/direct?topic=watch&displayId=ABCDE&filePath=xxx.yyy`,
@@ -56,7 +58,9 @@ describe("Direct HTTP request", ()=>{
   });
 
   it("responds ok and calls event handler for unwatch", ()=>{
-    simple.mock(unwatchRequest, "doOnIncomingPod").returnWith();
+    simple.mock(unwatchRequest, "doOnIncomingPod").callFn((query, resp)=>{
+      resp.send();
+    });
     return rp({
       method: "GET",
       uri: `http://localhost:${testPort}/messaging/direct?topic=unwatch&displayId=ABCDE&filePaths=xxx.yyy`,
@@ -68,10 +72,12 @@ describe("Direct HTTP request", ()=>{
   });
 
   it("responds ok and calls event handler for folder-watch", ()=>{
-    simple.mock(folderWatchRequest, "doOnIncomingPod").returnWith();
+    simple.mock(folderWatchRequest, "doOnIncomingPod").callFn((query, resp)=>{
+      resp.send();
+    });
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&displayId=ABCDE&filePaths=xxx.yyy/`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&displayId=ABCDE&filePath=xxx.yyy/`,
       json: true
     })
     .then(()=>{
@@ -80,7 +86,9 @@ describe("Direct HTTP request", ()=>{
   });
 
   it("responds ok and calls event handler for watchlist-compare", ()=>{
-      simple.mock(watchlistCompareRequest, "doOnIncomingPod").returnWith();
+      simple.mock(watchlistCompareRequest, "doOnIncomingPod").callFn((query, resp)=>{
+        resp.send();
+      });
       return rp({
         method: "GET",
         uri: `http://localhost:${testPort}/messaging/direct?topic=watchlist-compare&displayId=ABCDE&lastChanged=xxx`,

--- a/test/integration/direct-request-hook.js
+++ b/test/integration/direct-request-hook.js
@@ -1,0 +1,93 @@
+/* eslint-env mocha */
+
+const assert = require("assert");
+const rp = require("request-promise-native");
+const simple = require("simple-mock");
+const watchRequest = require("../../src/event-handlers/messages/watch");
+const folderWatchRequest = require("../../src/event-handlers/messages/folder-watch");
+const unwatchRequest = require("../../src/event-handlers/messages/unwatch");
+const watchlistCompareRequest = require("../../src/event-handlers/messages/watchlist-compare");
+
+const testPort = 9228;
+const BAD_REQUEST = 400;
+
+describe("Direct HTTP request", ()=>{
+
+  it("expects topic parameter", ()=>{
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?displayId=xxx`,
+      json: true
+    })
+    .then(()=>{
+      assert.fail("Should have rejected");
+    })
+    .catch(err=>{
+      assert(err.message.includes("Topic"));
+      assert(err.statusCode === BAD_REQUEST);
+    });
+  });
+
+  it("expects displayId parameter", ()=>{
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx`,
+      json: true
+    })
+    .then(()=>{
+      assert.fail("Should have rejected");
+    })
+    .catch(err=>{
+      assert(err.message.includes("displayId"));
+      assert(err.statusCode === BAD_REQUEST);
+    });
+  });
+
+  it("responds ok and calls event handler for watch", ()=>{
+    simple.mock(watchRequest, "doOnIncomingPod").returnWith();
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&displayId=ABCDE&filePath=xxx.yyy`,
+      json: true
+    })
+    .then(()=>{
+      assert(watchRequest.doOnIncomingPod.called)
+    });
+  });
+
+  it("responds ok and calls event handler for unwatch", ()=>{
+    simple.mock(unwatchRequest, "doOnIncomingPod").returnWith();
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=unwatch&displayId=ABCDE&filePaths=xxx.yyy`,
+      json: true
+    })
+    .then(()=>{
+      assert(unwatchRequest.doOnIncomingPod.called)
+    });
+  });
+
+  it("responds ok and calls event handler for folder-watch", ()=>{
+    simple.mock(folderWatchRequest, "doOnIncomingPod").returnWith();
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&displayId=ABCDE&filePaths=xxx.yyy/`,
+      json: true
+    })
+    .then(()=>{
+      assert(folderWatchRequest.doOnIncomingPod.called)
+    });
+  });
+
+  it("responds ok and calls event handler for watchlist-compare", ()=>{
+      simple.mock(watchlistCompareRequest, "doOnIncomingPod").returnWith();
+      return rp({
+        method: "GET",
+        uri: `http://localhost:${testPort}/messaging/direct?topic=watchlist-compare&displayId=ABCDE&lastChanged=xxx`,
+        json: true
+      })
+      .then(()=>{
+        assert(watchlistCompareRequest.doOnIncomingPod.called)
+      });
+    });
+});

--- a/test/integration/direct-request-hook.js
+++ b/test/integration/direct-request-hook.js
@@ -32,7 +32,7 @@ describe("Direct HTTP request", ()=>{
   it("expects endpointId parameter", ()=>{
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx&scheduleId=yyy`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&filePath=xxx.yyy&scheduleId=zzz`,
       json: true
     })
     .then(()=>{
@@ -47,7 +47,7 @@ describe("Direct HTTP request", ()=>{
   it("expects scheduleId parameter", ()=>{
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx&endpointId=ABCDE`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&endpointId=ABCDE&filePath=xxx.yyy`,
       json: true
     })
     .then(()=>{
@@ -62,7 +62,7 @@ describe("Direct HTTP request", ()=>{
   it("does not expect displayId parameter", ()=>{
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx&endpointId=ABCDE&displayId=yyy&scheduleId=zzz`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&endpointId=ABCDE&filePath=xxx.yyy&scheduleId=zzz&displayId=yyy`,
       json: true
     })
     .then(()=>{
@@ -70,6 +70,51 @@ describe("Direct HTTP request", ()=>{
     })
     .catch(err=>{
       assert(err.message.includes("Displays are not allowed"));
+      assert(err.statusCode === FORBIDDEN);
+    });
+  });
+
+  it("does not allow reboot", ()=>{
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=reboot&endpointId=ABCDE`,
+      json: true
+    })
+    .then(()=>{
+      assert.fail("Should have rejected");
+    })
+    .catch(err=>{
+      assert(err.message.includes("Topic is not valid"));
+      assert(err.statusCode === FORBIDDEN);
+    });
+  });
+
+  it("does not allow restart", ()=>{
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=restart&endpointId=ABCDE`,
+      json: true
+    })
+    .then(()=>{
+      assert.fail("Should have rejected");
+    })
+    .catch(err=>{
+      assert(err.message.includes("Topic is not valid"));
+      assert(err.statusCode === FORBIDDEN);
+    });
+  });
+
+  it("does not allow screenshot", ()=>{
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=screenshot&endpointId=ABCDE`,
+      json: true
+    })
+    .then(()=>{
+      assert.fail("Should have rejected");
+    })
+    .catch(err=>{
+      assert(err.message.includes("Topic is not valid"));
       assert(err.statusCode === FORBIDDEN);
     });
   });

--- a/test/integration/direct-request-hook.js
+++ b/test/integration/direct-request-hook.js
@@ -10,13 +10,14 @@ const watchlistCompareRequest = require("../../src/event-handlers/messages/watch
 
 const testPort = 9228;
 const BAD_REQUEST = 400;
+const FORBIDDEN = 403;
 
 describe("Direct HTTP request", ()=>{
 
   it("expects topic parameter", ()=>{
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?displayId=xxx`,
+      uri: `http://localhost:${testPort}/messaging/direct?endpointId=xxx&scheduleId=yyy`,
       json: true
     })
     .then(()=>{
@@ -28,18 +29,48 @@ describe("Direct HTTP request", ()=>{
     });
   });
 
-  it("expects displayId parameter", ()=>{
+  it("expects endpointId parameter", ()=>{
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx&scheduleId=yyy`,
       json: true
     })
     .then(()=>{
       assert.fail("Should have rejected");
     })
     .catch(err=>{
-      assert(err.message.includes("displayId"));
+      assert(err.message.includes("endpointId"));
       assert(err.statusCode === BAD_REQUEST);
+    });
+  });
+
+  it("expects scheduleId parameter", ()=>{
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx&endpointId=ABCDE`,
+      json: true
+    })
+    .then(()=>{
+      assert.fail("Should have rejected");
+    })
+    .catch(err=>{
+      assert(err.message.includes("scheduleId"));
+      assert(err.statusCode === BAD_REQUEST);
+    });
+  });
+
+  it("does not expect displayId parameter", ()=>{
+    return rp({
+      method: "GET",
+      uri: `http://localhost:${testPort}/messaging/direct?topic=xxx&endpointId=ABCDE&displayId=yyy&scheduleId=zzz`,
+      json: true
+    })
+    .then(()=>{
+      assert.fail("Should have rejected");
+    })
+    .catch(err=>{
+      assert(err.message.includes("Displays are not allowed"));
+      assert(err.statusCode === FORBIDDEN);
     });
   });
 
@@ -49,7 +80,7 @@ describe("Direct HTTP request", ()=>{
     });
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&displayId=ABCDE&filePath=xxx.yyy`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&endpointId=ABCDE&filePath=xxx.yyy&scheduleId=zzz`,
       json: true
     })
     .then(()=>{
@@ -63,7 +94,7 @@ describe("Direct HTTP request", ()=>{
     });
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=unwatch&displayId=ABCDE&filePaths=xxx.yyy`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=unwatch&endpointId=ABCDE&filePaths=xxx.yyy&scheduleId=zzz`,
       json: true
     })
     .then(()=>{
@@ -77,7 +108,7 @@ describe("Direct HTTP request", ()=>{
     });
     return rp({
       method: "GET",
-      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&displayId=ABCDE&filePath=xxx.yyy/`,
+      uri: `http://localhost:${testPort}/messaging/direct?topic=watch&endpointId=ABCDE&filePath=xxx.yyy/&scheduleId=zzz`,
       json: true
     })
     .then(()=>{
@@ -91,7 +122,7 @@ describe("Direct HTTP request", ()=>{
       });
       return rp({
         method: "GET",
-        uri: `http://localhost:${testPort}/messaging/direct?topic=watchlist-compare&displayId=ABCDE&lastChanged=xxx`,
+        uri: `http://localhost:${testPort}/messaging/direct?topic=watchlist-compare&endpointId=ABCDE&lastChanged=xxx&scheduleId=zzz`,
         json: true
       })
       .then(()=>{

--- a/test/integration/watch.js
+++ b/test/integration/watch.js
@@ -72,7 +72,7 @@ describe("WATCH : Integration", ()=>{
 
       return redis.getString(`meta:${validFilePath}:version`)
       .then((resp)=>assert(!resp))
-      .then(watch.doOnIncomingPod.bind(null, {displayId, filePath: validFilePath, version}))
+      .then(watch.doOnIncomingPod.bind(null, {displayId, filePath: validFilePath, version}, null))
       .then(()=>{
         const reply = displayConnections.sendMessage.lastCall.args[1];
         assert.equal(reply.token.data.displayId, displayId);
@@ -103,7 +103,7 @@ describe("WATCH : Integration", ()=>{
         displayId,
         filePath: validFilePath,
         version: knownGCSversion
-      }))
+      }, null))
       .then(()=>{
         const reply = displayConnections.sendMessage.lastCall.args[1];
         console.log(reply);


### PR DESCRIPTION
## Description
Support for watch/unwatch/folder-watch/watchlist-compare requests via HTTP

## Motivation and Context
This is a part of the ongoing implementation for the current epic.

## How Has This Been Tested?
Integration tests.

## Reminder Checklist

 [] Messaging service stage environment is validated to still be working the same as prod

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
