### PR TITLE
Fix/unwatch file paths param handling

### DIFF
--- a/src/webhooks/endpoints/direct.js
+++ b/src/webhooks/endpoints/direct.js
@@ -5,7 +5,7 @@ const setCorsHeaders = require("../set-cors-headers");
 
 const validTopics = ["WATCH", "UNWATCH", "WATCHLIST-COMPARE"];
 
-module.exports = (req, resp) => {
+module.exports = (req, resp) => { // eslint-disable-line max-statements
   setCorsHeaders(req, resp);
 
   const {topic, endpointId} = req.query;
@@ -13,6 +13,9 @@ module.exports = (req, resp) => {
   logger.log(`Received ${topic} request from Viewer id=${endpointId}`);
 
   if (invalidInput(req.query, resp)) {return;}
+  if (topic.toUpperCase() === "UNWATCH") {
+    req.query.filePaths = req.query.filePaths.split(",");
+  }
 
 //  checkAuthorization(req.query, endpointId, resp);
 
@@ -25,7 +28,7 @@ module.exports = (req, resp) => {
   .then(()=>logger.log(`Request from Viewer id=${endpointId} processed.`));
 }
 
-function invalidInput({topic, endpointId, scheduleId, displayId} = {}, resp) { // eslint-disable-line max-statements
+function invalidInput({topic, endpointId, scheduleId, displayId, filePaths} = {}, resp) { // eslint-disable-line max-statements
   const invalid = invalidHandler.bind(null, resp);
 
   if (!topic) {return invalid(paramErrors.missingTopic);}
@@ -33,6 +36,9 @@ function invalidInput({topic, endpointId, scheduleId, displayId} = {}, resp) { /
   if (!endpointId) {return invalid(paramErrors.missingEndpointId);}
   if (!scheduleId) {return invalid(paramErrors.missingScheduleId);}
   if (displayId) {return invalid(paramErrors.displaysNotAllowed);}
+  if (topic.toUpperCase() === "UNWATCH" && !filePaths) {
+    return invalid(paramErrors.missingFilePaths);
+  }
 
   return false;
 }

--- a/src/webhooks/endpoints/param-errors.js
+++ b/src/webhooks/endpoints/param-errors.js
@@ -27,6 +27,10 @@ module.exports = {
     code: 400,
     msg: "Topic (topic) is required"
   },
+  missingFilePaths: {
+    code: 400,
+    msg: "File paths (filePaths) are required"
+  },
   invalidSchedule: {
     code: 404,
     msg: "Schedule is not valid"


### PR DESCRIPTION
## Description
UNWATCH direct: convert filePaths param to string array before calling unwatch handler.

## Motivation and Context
Unwatch handler is expecting and array of strings ( filePaths ), but direct HTTP requests receive plain strings. This change ensures the filePaths is provided and is treated as a string array before calling the unwatch handler functionality.

## How Has This Been Tested?
I complemented current unwatch test to verify for an array being generated and added tests for validating filePaths, and for hanbdling multiple filePaths.

I also tested manually against MS staging:

```
curl 'https://services-stage.risevision.com/messaging/direct?topic=unwatch&endpointId=ABCDE&filePaths=xxx.yyy&scheduleId=zzz'
{"topic":"unwatch-result"}

curl 'httsion.com/messaging/direct?topic=unwatch&endpointId=ABCDE&filePaths=xxx.yyy%2Caaaa.bbbb%2Cssss.rrrr&scheduleId=zzz'
{"topic":"unwatch-result"}
```

## Reminder Checklist

 [x] Messaging service stage environment is validated to still be working the same as prod

## Release Plan:
To be released immediately. As this relates to direct requests only, should not affect existing functionality. Simple revert is enough to roll back.

#### Release Checklist Items Skipped?
No need to notify support. No need to update documentation.
