### PR TITLE
Remove content sentinel prefix handling

### DIFF
--- a/src/google-pubsub/index.js
+++ b/src/google-pubsub/index.js
@@ -38,11 +38,9 @@ const retrySettings = {
 }; /* eslint no-magic-numbers: "off", no-multi-spaces: "off" */
 module.exports = {
   publishDisconnection(displayId) {
-    if (displayId && displayId.startsWith("content-sentinel-")) {return;}
     module.exports.publish(messageObject(displayId, "disconnected"));
   },
   publishConnection(displayId) {
-    if (displayId && displayId.startsWith("content-sentinel-")) {return;}
     module.exports.publish(messageObject(displayId, "connected"));
   },
   publish(msg = {}, topic = topicPath) {

--- a/test/unit/google-pubsub.js
+++ b/test/unit/google-pubsub.js
@@ -26,14 +26,6 @@ describe("Google PubSub", ()=>{
     assert.deepEqual(publishedMessage.status, expectedStatus);
   });
 
-  it("does not publish message on display connection with prefix", ()=>{
-      const testId = "content-sentinel-test-id";
-
-      googlePubSub.publishConnection(testId);
-
-      assert(!publishStub.callCount);
-  });
-
   it("publishes message on display disconnection", ()=>{
     const expectedStatus = "disconnected"
     const testId = "test-id";
@@ -44,13 +36,5 @@ describe("Google PubSub", ()=>{
 
     assert.deepEqual(publishedMessage.id, testId);
     assert.deepEqual(publishedMessage.status, expectedStatus);
-  });
-
-  it("does not publish message on display disconnection with prefix", ()=>{
-      const testId = "content-sentinel-test-id";
-
-      googlePubSub.publishDisconnection(testId);
-
-      assert(!publishStub.callCount);
   });
 });


### PR DESCRIPTION
Since Players that have their own caching mechanism will not be using
Content Sentinel, the prefix is no longer necessary. Content Sentinel
connections to MS will always be from a Player that does not have any
other connection. Shared Schedules never connect to MS, and older
Players never use Content Sentinel.

See
https://docs.google.com/document/d/1hLXRA5_koBcsZHTIaFdrNxr8WDvD6tI7T6q3CeOpTA8/edit#bookmark=id.92lyimt9h6ol

### Related PR
https://github.com/Rise-Vision/content-sentinel/pull/100

## How Has This Been Tested?
Will test manual connection in staging

## Reminder Checklist

 [] Messaging service stage environment is validated to still be working the same as prod

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
