### PR TITLE
point to redis primary

### DIFF
--- a/src/db/redis/datastore.js
+++ b/src/db/redis/datastore.js
@@ -1,6 +1,6 @@
 const util = require("util");
 const redis = require("redis");
-const gkeHostname = "display-ms-redis-master";
+const gkeHostname = "display-ms-redis-primary";
 const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : gkeHostname;
 
 let client = null;

--- a/src/redis-pubsub/index.js
+++ b/src/redis-pubsub/index.js
@@ -3,7 +3,7 @@ const logger = require("../logger");
 const podsChannel = "inter-pod-publish";
 const expiredKeyChannelPattern = "__keyevent*expired";
 const redis = require("redis");
-const gkeHostname = "display-ms-redis-master";
+const gkeHostname = "display-ms-redis-primary";
 const redisHost = process.env.NODE_ENV === "test" ? "127.0.0.1" : gkeHostname;
 const handlers = require("../event-handlers/messages");
 const missedHeartbeat = require("../event-handlers/missed-heartbeat");


### PR DESCRIPTION
## Description
Point to new master display-ms-redis-primary

## Motivation and Context
Current display-ms-redis-master has no data persistence. Switching to a new deployment is the swiftest way of enabling this as discussed [here](https://docs.google.com/document/d/11ppHdOFX6UAYpiWsbwcp27MH0Sda7wB9QZtKuw8pBlU/edit#).

This work is necessary before enabling display/endpoint validation and banning, to prevent situation where a pods restart, the database reset ( as currently it has no persistence ) and all displays/endpoints are denied access to MS.

## How Has This Been Tested?
All steps were tested in staging.

## Reminder Checklist

 [x] Messaging service stage environment is validated to still be working the same as prod

## Release Plan:
To be executed on Thursday or Friday as part of Redis state retention plan.
In case of issues current master node can be configured as persistent with a copy of current redis data.

#### Release Checklist Items Skipped?
No, the mentioned document servers as documentation.
