### PR TITLE
Feature/enable validations

### DIFF
--- a/src/websocket/primus-setup.js
+++ b/src/websocket/primus-setup.js
@@ -1,13 +1,13 @@
 const logger = require("../logger");
 const querystring = require("querystring");
 const url = require("url");
-// const dbApi = require("../db/api");
+const dbApi = require("../db/api");
 const displayConnections = require("../event-handlers/display-connections");
 const handlers = require("../event-handlers/messages");
 
 const invalidIds = ["undefined", "null"];
 
-/* const checkBanned = (type, id, done) => {
+const checkBanned = (type, id, done) => {
   dbApi.validation.isBannedEndpointId(id)
   .then(isBanned => {
     if (isBanned) {
@@ -20,7 +20,7 @@ const invalidIds = ["undefined", "null"];
 
     done();
   });
-} */
+}
 
 const authorizeSchedule = (scheduleId, endpointId, done) => {
   if (!scheduleId || !endpointId || [scheduleId, endpointId].some(id=>invalidIds.includes(id))) {
@@ -31,7 +31,7 @@ const authorizeSchedule = (scheduleId, endpointId, done) => {
     });
   }
 
-  /* dbApi.validation.isValidScheduleId(scheduleId)
+  dbApi.validation.isValidScheduleId(scheduleId)
   .then(isValid => {
     if (!isValid) {
       logger.log(`Invalid schedule id (scheduleId: ${scheduleId})`);
@@ -42,8 +42,7 @@ const authorizeSchedule = (scheduleId, endpointId, done) => {
     }
 
     checkBanned('endpoint', endpointId, done);
-  }); */
-  done();
+  });
 }
 
 const authorizeDisplay = (displayId, machineId, done) => {
@@ -55,7 +54,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
     });
   }
 
-  /* dbApi.validation.isValidDisplayId(displayId)
+  dbApi.validation.isValidDisplayId(displayId)
   .then(isValid => {
     if (!isValid) {
       logger.log(`Invalid display id (displayId: ${displayId})`);
@@ -66,8 +65,7 @@ const authorizeDisplay = (displayId, machineId, done) => {
     }
 
     checkBanned('display', displayId, done);
-  }); */
-  done();
+  });
 }
 
 module.exports = {

--- a/test/integration/connection-params-displays.js
+++ b/test/integration/connection-params-displays.js
@@ -155,7 +155,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    xit("rejects a connection if displayid is not valid", ()=>{
+    it("rejects a connection if displayid is not valid", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(false);
 
       const displayId = "testId";
@@ -175,7 +175,7 @@ describe("MS Connection : displays : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    xit("rejects a connection if display id is banned", ()=>{
+    it("rejects a connection if display id is banned", ()=>{
       simple.mock(dbApi.validation, "isValidDisplayId").resolveWith(true);
       simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
 

--- a/test/integration/connection-params-schedules.js
+++ b/test/integration/connection-params-schedules.js
@@ -137,7 +137,7 @@ describe("MS Connection : Schedules : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    xit("rejects a connection if schedule id is not valid", ()=>{
+    it("rejects a connection if schedule id is not valid", ()=>{
       simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(false);
 
       const scheduleId = "testId";
@@ -157,7 +157,7 @@ describe("MS Connection : Schedules : Integration", ()=>{
       .then(()=>ms.end());
     });
 
-    xit("rejects a connection if and endpoint id is banned", ()=>{
+    it("rejects a connection if and endpoint id is banned", ()=>{
       simple.mock(dbApi.validation, "isValidScheduleId").resolveWith(true);
       simple.mock(dbApi.validation, "isBannedEndpointId").resolveWith(true);
 


### PR DESCRIPTION
## Description
Enables display/schedule validation and endpoint bans in both Primus and direct connections.

## Motivation and Context
Prevent abuse of displays / endpoints

## How Has This Been Tested?
I tested all scenarios:

- displays Primus

```
MS_STAGING=1 node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?displayId=test-manual&machineId=1234
messaging error
{ Error: unexpected server response (404)

MS_STAGING=1 DISPLAY_ID=VALID_DISPLAY_ID node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?displayId=VALID_DISPLAY_ID&machineId=1234
messaging service connected https://services-stage.risevision.com

curl -u TEST "https://services-stage.risevision.com/messaging/ban?id=VALID_DISPLAY_ID"

MS_STAGING=1 DISPLAY_ID=VALID_DISPLAY_ID node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?displayId=VALID_DISPLAY_ID&machineId=1234
messaging error
{ Error: unexpected server response (403)

curl -u TEST "https://services-stage.risevision.com/messaging/unban?id=VALID_DISPLAY_ID"
```

- endpoints Primus

```
 MS_STAGING=1 SCHEDULE_ID=xxx node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=xxx&endpointId=1234
messaging error
{ Error: unexpected server response (404) }

MS_STAGING=1 SCHEDULE_ID=VALID_SCHEDULE_ID node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=VALID_SCHEDULE_ID&endpointId=1234
messaging service connected https://services-stage.risevision.com

curl -u TEST "https:/e.risevision.com/messaging/ban?id=1234"

MS_STAGING=1 SCHEDULE_ID=VALID_SCHEDULE_ID node test/manual/test.js
Connecting to https://services-stage.risevision.com/messaging?scheduleId=VALID_SCHEDULE_ID&endpointId=1234
messaging error
{ Error: unexpected server response (403)

curl -u TEST "https:/e.risevision.com/messaging/unban?id=1234"
```

- endpoints direct

```
curl "https://services-stage.risevision.com/messaging/direct?topic=watchlist-compare&endpointId=VALID_ENDPOINT_ID&scheduleId=null&lastChanged=0"
Schedule is not valid

curl "https://sion.com/messaging/direct?topic=watchlist-compare&endpointId=VALID_ENDPOINT_ID&scheduleId=VALID_SCHEDULE_ID&lastChanged=0"
<OK RESPONSE>

curl -u TEST "https://services-stage.risevision.com/messaging/ban?id=VALID_ENDPOINT_ID"

curl "https://services-stage.risevision.com/messaging/direct?topic=watchlist-compare&endpointId=VALID_ENDPOINT_ID&scheduleId=VALID_SCHEDULE_ID&lastChanged=0"
Endpoint is banned

curl -u TEST "https://services-stage.risevision.com/messaging/unban?id=VALID_ENDPOINT_ID"
```

## Reminder Checklist

 [x] Messaging service stage environment is validated to still be working the same as prod - sent screenshot on staging active display

## Release Plan:
To be released after production Redis is persisted and validated.
Support will be notified that these restrictions are coming into effect.

#### Release Checklist Items Skipped?
No
