### PR TITLE
Fix missing resp parameter on EMPTYFOLDER

### DIFF
--- a/src/event-handlers/messages/folder-watch.js
+++ b/src/event-handlers/messages/folder-watch.js
@@ -44,7 +44,7 @@ module.exports = {
       })
     })
     .catch((err)=>{
-      watchError(err, folderPath, displayId);
+      watchError(err, folderPath, displayId, resp);
     });
   }
 };

--- a/src/event-handlers/watch-error.js
+++ b/src/event-handlers/watch-error.js
@@ -15,7 +15,7 @@ module.exports = function(err = {}, filePath, displayId, resp) { // eslint-disab
     msg: `There was an error processing WATCH:${err.message}`
   };
 
-  const httpStatus = err.message === "NOEXIST" ? OK : SERVER_ERROR;
+  const httpStatus = ["NOEXIST", "EMPTYFOLDER"].includes(err.message) ? OK : SERVER_ERROR;
 
   return resp ? resp.status(httpStatus).send(message) : displayConnections.sendMessage(displayId, message);
 }


### PR DESCRIPTION
## Description
Fix missing parameter for direct http WATCH in EMPTYFOLDER case.

## Motivation and Context
Defect [107](https://github.com/Rise-Vision/messaging-service/issues/107)

## How Has This Been Tested?
- Confirmed on staging

![fix-direct](https://user-images.githubusercontent.com/1511535/116740974-b5475580-a9c3-11eb-92a0-5494cf03a1d9.png)

## Reminder Checklist

 [] Messaging service stage environment is validated to still be working the same as prod

## Release Plan:
- Monday release