### PR TITLE
Add ping handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const coreGET = require("./src/webhooks/core/get-handler");
 const coreIdUpdate = require("./src/webhooks/core/id-update-handler");
 const endpoints = require("./src/webhooks/endpoints/endpoint-handlers");
 const direct = require("./src/webhooks/endpoints/direct");
+const ping = require("./src/webhooks/endpoints/ping");
 const presencePOST = require("./src/webhooks/presence/post-handler");
 const presenceOPTIONS = require("./src/webhooks/presence/options-handler");
 const jsonParser = require("body-parser").json();
@@ -44,6 +45,7 @@ app.get("/messaging/core/idUpdate", coreIdUpdate);
 app.get("/messaging/ban", endpoints.handleBan);
 app.get("/messaging/unban", endpoints.handleUnban);
 app.get("/messaging/direct", direct);
+app.get("/messaging/ping", ping);
 
 app.post("/messaging/pubsub", jsonParser, pubsubConnectorPOST);
 

--- a/src/webhooks/endpoints/ping.js
+++ b/src/webhooks/endpoints/ping.js
@@ -1,0 +1,6 @@
+const setCorsHeaders = require("../set-cors-headers");
+
+module.exports = (req, resp) => {
+  setCorsHeaders(req, resp);
+  resp.end("pong");
+}


### PR DESCRIPTION
## Description
Add a basic ping check for viewer networking compatibility checks

## Motivation and Context
[network requirements](https://docs.google.com/document/d/13oYogLEfhNTf3T2eIx0QQ6mt1w8d9rwmIHtzWRppgQw/edit#heading=h.d3725565jynb)

## How Has This Been Tested?
 - Confirmed on staging MS websocket connection is still possible
 - Confirmed on staging `/messaging/ping` with origin test.risevision.com returns CORS headers and 200
